### PR TITLE
Add support for multiple -u arguments

### DIFF
--- a/streamrip/cli.py
+++ b/streamrip/cli.py
@@ -31,6 +31,7 @@ if not os.path.isdir(CACHE_DIR):
     "--urls",
     metavar="URLS",
     help="Url from Qobuz, Tidal, SoundCloud, or Deezer",
+    multiple=True,
 )
 @click.option(
     "-q",

--- a/streamrip/core.py
+++ b/streamrip/core.py
@@ -111,44 +111,45 @@ class MusicDL(list):
         else:
             self.db = []
 
-    def handle_urls(self, url: str):
-        """Download a url.
+    def handle_urls(self, urls):
+        for url in urls:
+            """Download a url.
 
-        :param url:
-        :type url: str
-        :raises InvalidSourceError
-        :raises ParsingError
-        """
-        # youtube is handled by youtube-dl, so much of the
-        # processing is not necessary
-        youtube_urls = self.youtube_url_parse.findall(url)
-        if youtube_urls != []:
-            self.extend(YoutubeVideo(u) for u in youtube_urls)
+            :param url:
+            :type url: str
+            :raises InvalidSourceError
+            :raises ParsingError
+            """
+            # youtube is handled by youtube-dl, so much of the
+            # processing is not necessary
+            youtube_urls = self.youtube_url_parse.findall(url)
+            if youtube_urls != []:
+                self.extend(YoutubeVideo(u) for u in youtube_urls)
 
-        parsed = self.parse_urls(url)
-        if not parsed and len(self) == 0:
-            if "last.fm" in url:
-                message = (
-                    f"For last.fm urls, use the {click.style('lastfm', fg='yellow')} "
-                    f"command. See {click.style('rip lastfm --help', fg='yellow')}."
-                )
-            else:
-                message = url
+            parsed = self.parse_urls(url)
+            if not parsed and len(self) == 0:
+                if "last.fm" in url:
+                    message = (
+                        f"For last.fm urls, use the {click.style('lastfm', fg='yellow')} "
+                        f"command. See {click.style('rip lastfm --help', fg='yellow')}."
+                    )
+                else:
+                    message = url
 
-            raise ParsingError(message)
+                raise ParsingError(message)
 
-        for source, url_type, item_id in parsed:
-            if item_id in self.db:
-                logger.info(
-                    f"ID {item_id} already downloaded, use --no-db to override."
-                )
-                click.secho(
-                    f"ID {item_id} already downloaded, use --no-db to override.",
-                    fg="magenta",
-                )
-                continue
+            for source, url_type, item_id in parsed:
+                if item_id in self.db:
+                    logger.info(
+                        f"ID {item_id} already downloaded, use --no-db to override."
+                    )
+                    click.secho(
+                        f"ID {item_id} already downloaded, use --no-db to override.",
+                        fg="magenta",
+                    )
+                    continue
 
-            self.handle_item(source, url_type, item_id)
+                self.handle_item(source, url_type, item_id)
 
     def handle_item(self, source: str, media_type: str, item_id: str):
         """Get info and parse into a Media object.

--- a/streamrip/core.py
+++ b/streamrip/core.py
@@ -112,44 +112,44 @@ class MusicDL(list):
             self.db = []
 
     def handle_urls(self, urls):
-        for url in urls:
-            """Download a url.
+        """Download a url.
 
-            :param url:
-            :type url: str
-            :raises InvalidSourceError
-            :raises ParsingError
-            """
-            # youtube is handled by youtube-dl, so much of the
-            # processing is not necessary
-            youtube_urls = self.youtube_url_parse.findall(url)
-            if youtube_urls != []:
-                self.extend(YoutubeVideo(u) for u in youtube_urls)
+        :param url:
+        :type url: str
+        :raises InvalidSourceError
+        :raises ParsingError
+        """
+        url = ' '.join(urls)
+        # youtube is handled by youtube-dl, so much of the
+        # processing is not necessary
+        youtube_urls = self.youtube_url_parse.findall(url)
+        if youtube_urls != []:
+            self.extend(YoutubeVideo(u) for u in youtube_urls)
 
-            parsed = self.parse_urls(url)
-            if not parsed and len(self) == 0:
-                if "last.fm" in url:
-                    message = (
-                        f"For last.fm urls, use the {click.style('lastfm', fg='yellow')} "
-                        f"command. See {click.style('rip lastfm --help', fg='yellow')}."
-                    )
-                else:
-                    message = url
+        parsed = self.parse_urls(url)
+        if not parsed and len(self) == 0:
+            if "last.fm" in url:
+                message = (
+                    f"For last.fm urls, use the {click.style('lastfm', fg='yellow')} "
+                    f"command. See {click.style('rip lastfm --help', fg='yellow')}."
+                )
+            else:
+                message = url
 
-                raise ParsingError(message)
+            raise ParsingError(message)
 
-            for source, url_type, item_id in parsed:
-                if item_id in self.db:
-                    logger.info(
-                        f"ID {item_id} already downloaded, use --no-db to override."
-                    )
-                    click.secho(
-                        f"ID {item_id} already downloaded, use --no-db to override.",
-                        fg="magenta",
-                    )
-                    continue
+        for source, url_type, item_id in parsed:
+            if item_id in self.db:
+                logger.info(
+                    f"ID {item_id} already downloaded, use --no-db to override."
+                )
+                click.secho(
+                    f"ID {item_id} already downloaded, use --no-db to override.",
+                    fg="magenta",
+                )
+                continue
 
-                self.handle_item(source, url_type, item_id)
+            self.handle_item(source, url_type, item_id)
 
     def handle_item(self, source: str, media_type: str, item_id: str):
         """Get info and parse into a Media object.


### PR DESCRIPTION
Simple feature which allows for the use of multiple `-u` arguments. Alternative file-less version of `-t` essentially.
Arguments usage has changed none, the argument just needs to be called for every URL like so:
```
$ rip -u https://www.deezer.com/us/track/781592622 -u https://www.deezer.com/us/track/88911001
```

It's simple code changes but it seems to work flawlessly for all the testing I've done with it.

All it does is set multiple under the URLS argument to True, and then sets the `handle_urls()` function to instead take in an array and loop the method through it.