### PR TITLE
Update and Obfuscate Tidal API Creds

### DIFF
--- a/streamrip/constants.py
+++ b/streamrip/constants.py
@@ -1,7 +1,7 @@
 """Constants that are kept in one place."""
 
 import mutagen.id3 as id3
-import bas64
+import base64
 
 AGENT = "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:83.0) Gecko/20100101 Firefox/83.0"
 

--- a/streamrip/constants.py
+++ b/streamrip/constants.py
@@ -1,6 +1,7 @@
 """Constants that are kept in one place."""
 
 import mutagen.id3 as id3
+import bas64
 
 AGENT = "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:83.0) Gecko/20100101 Firefox/83.0"
 

--- a/streamrip/constants.py
+++ b/streamrip/constants.py
@@ -174,8 +174,8 @@ MEDIA_TYPES = {"track", "album", "artist", "label", "playlist", "video"}
 COVER_SIZES = ("thumbnail", "small", "large", "original")
 
 TIDAL_CLIENT_INFO = {
-    "id": "Pzd0ExNVHkyZLiYN",
-    "secret": "W7X6UvBaho+XOi1MUeCX6ewv2zTdSOV3Y7qC3p3675I=",
+    "id": base64.b64decode("OFNFWldhNEoxTlZDNVU1WQ==").decode("iso-8859-1"),
+    "secret": base64.b64decode("b3dVWURreGRkeis5RnB2R1gyNERseEVDTnRGRU1CeGlwVTBsQmZyYnE2MD0=").decode("iso-8859-1"),
 }
 
 QOBUZ_BASE = "https://www.qobuz.com/api.json/0.2"


### PR DESCRIPTION
Solves #277 and #278 .
Using credentials from https://github.com/morguldir/python-tidal/commit/50f1afcd2079efb2b4cf694ef5a7d67fdf619d09.