### PR TITLE
Update Tidal API credentials.

### DIFF
--- a/streamrip/constants.py
+++ b/streamrip/constants.py
@@ -176,9 +176,9 @@ MEDIA_TYPES = {"track", "album", "artist", "label", "playlist", "video"}
 COVER_SIZES = ("thumbnail", "small", "large", "original")
 
 TIDAL_CLIENT_INFO = {
-    "id": base64.b64decode("OFNFWldhNEoxTlZDNVU1WQ==").decode("iso-8859-1"),
+    "id": base64.b64decode("elU0WEhWVmtjMnREUG80dA==").decode("iso-8859-1"),
     "secret": base64.b64decode(
-        "b3dVWURreGRkeis5RnB2R1gyNERseEVDTnRGRU1CeGlwVTBsQmZyYnE2MD0="
+        "VkpLaERGcUpQcXZzUFZOQlY2dWtYVEptd2x2YnR0UDd3bE1scmM3MnNlND0="
     ).decode("iso-8859-1"),
 }
 


### PR DESCRIPTION
Update credentials to support Normal/High/HiFi/Master

Uses credentials from [yaronzz/Tidal-Media-Downloader@3d4b143](https://github.com/yaronzz/Tidal-Media-Downloader/commit/3d4b143c741e6cef37ce8d7caae89d0c8ee23f08)