### PR TITLE
Spoofbuz : Fix regex for app_id

### DIFF
--- a/streamrip/spoofbuz.py
+++ b/streamrip/spoofbuz.py
@@ -26,9 +26,9 @@ class Spoofer:
             r'(?P<info>[\w=]+)",extras:"(?P<extras>[\w=]+)"'
         )
         self.app_id_regex = (
-            r'{app_id:"(?P<app_id>\d{9})",app_secret:"\w{32}",base_port:"80"'
-            r',base_url:"https://www\.qobuz\.com",base_method:"/api\.js'
-            r'on/0\.2/"},n\.base_url="https://play\.qobuz\.com"'
+            r'\{app_id:"(?P<app_id>\d{9})",app_secret:"\w{32}",base_port:"80"'
+            r',base_url:"https://www\.qobuz\.com",base_method:"/api\.json/0\.2'
+            r'/"\},n\.base_url="https://play\.qobuz\.com"'
         )
         login_page_request = requests.get("https://play.qobuz.com/login")
         login_page = login_page_request.text


### PR DESCRIPTION
The regex used to extract app_id in Spoofbuz class (for Qobuz client) had some errors. 