### PR TITLE
fix: multiple "600" in original cover URL filename

### DIFF
--- a/streamrip/utils.py
+++ b/streamrip/utils.py
@@ -318,7 +318,7 @@ def get_cover_urls(resp: dict, source: str) -> Optional[dict]:
 
     if source == "qobuz":
         cover_urls = resp["image"]
-        cover_urls["original"] = cover_urls["large"].replace("600", "org")
+        cover_urls["original"] = "org".join(cover_urls["large"].rsplit('600', 1))
         return cover_urls
 
     if source == "tidal":


### PR DESCRIPTION
- Fixes a minor issue when trying to set a Qobuz original cover URL. 

Streamrip replaces all occurrences of `600` when setting `cover_urls["original"]` which leads to raising an error when downloading the cover art for this album: https://www.qobuz.com/no-en/album/swan-alexandros/0060040678390