### PR TITLE
Update Qobuz interpreter (artist) URL support

### DIFF
--- a/rip/utils.py
+++ b/rip/utils.py
@@ -6,6 +6,9 @@ from typing import Tuple
 from streamrip.constants import AGENT
 from streamrip.utils import gen_threadsafe_session
 
+interpreter_artist_id_regex = re.compile(
+    r"https?://www\.qobuz\.com/\w\w-\w\w/interpreter/[-\w]+/(?P<artistId>[0-9]+)"
+)
 interpreter_artist_regex = re.compile(r"getSimilarArtist\(\s*'(\w+)'")
 
 
@@ -13,9 +16,14 @@ def extract_interpreter_url(url: str) -> str:
     """Extract artist ID from a Qobuz interpreter url.
 
     :param url: Urls of the form "https://www.qobuz.com/us-en/interpreter/{artist}/download-streaming-albums"
+    or "https://www.qobuz.com/us-en/interpreter/the-last-shadow-puppets/{artistId}}"
     :type url: str
     :rtype: str
     """
+    urlMatch = interpreter_artist_id_regex.search(url)
+    if urlMatch:
+        return urlMatch.group('artistId')
+    
     session = gen_threadsafe_session({"User-Agent": AGENT})
     r = session.get(url)
     match = interpreter_artist_regex.search(r.text)

--- a/rip/utils.py
+++ b/rip/utils.py
@@ -20,10 +20,10 @@ def extract_interpreter_url(url: str) -> str:
     :type url: str
     :rtype: str
     """
-    urlMatch = interpreter_artist_id_regex.search(url)
-    if urlMatch:
-        return urlMatch.group('artistId')
-    
+    url_match = interpreter_artist_id_regex.search(url)
+    if url_match:
+        return url_match.group("artistId")
+
     session = gen_threadsafe_session({"User-Agent": AGENT})
     r = session.get(url)
     match = interpreter_artist_regex.search(r.text)


### PR DESCRIPTION
The Qobuz main store website uses links in the following format for artists now:

````html
https://www.qobuz.com/<CountryCode>/interpreter/<slug>/<ArtistId>
````

Like for example:
<https://www.qobuz.com/us-en/interpreter/the-last-shadow-puppets/384393>

The old code tries to extract the artist ID from the html source, but the used regex won't return a result for links like the example above.  
This change will first try to get the artist ID directly from the interpreter URL and use the old method as fallback.