### PR TITLE
Added feature to automatically download the first search result

### DIFF
--- a/rip/cli.py
+++ b/rip/cli.py
@@ -182,6 +182,12 @@ class SearchCommand(Command):
             flag=False,
             default="album",
         ),
+        option(
+            "first",
+            "-f",
+            "Download the first result immediately",
+            flag=True
+        )
     ]
 
     help = (
@@ -190,18 +196,27 @@ class SearchCommand(Command):
         "Search for <title>444</title> by <title>Jay-Z</title> on TIDAL\n"
         "$ <cmd>rip search --source tidal '444'</cmd>\n\n"
         "Search for <title>Bob Dylan</title> on Deezer\n"
-        "$ <cmd>rip search --type artist --source deezer 'bob dylan'</cmd>\n"
+        "$ <cmd>rip search --type artist --source deezer 'bob dylan'</cmd>\n\n"
+        "Search for <title>Reckoning Night</title> by <title>Sonata Arctica</title> and download the first result\n"
+        "$ <cmd>rip search --first 'sonata arctica reckoning night'</cmd>\n"
     )
 
     def handle(self):
         query = self.argument("query")
-        source, type = clean_options(self.option("source"), self.option("type"))
+        source, type, takeFirst = clean_options(self.option("source"), self.option("type"), self.option("first"))
         assert isinstance(source, str)
         assert isinstance(type, str)
+        assert isinstance(takeFirst, bool)
 
         config = Config()
         core = RipCore(config)
-
+        if takeFirst:
+            if core.quick_search(query,source,type):
+                core.download()
+            else:
+                self.line("<error>No items found, exiting.</error>")
+            return
+        
         if core.interactive_search(query, source, type):
             core.download()
         else:

--- a/rip/core.py
+++ b/rip/core.py
@@ -803,6 +803,28 @@ class RipCore(list):
                         self.append(results[i])
                 return True
 
+    def quick_search(
+        self,
+        query: str,
+        source: str = "qobuz",
+        media_type: str = "album"
+    ) -> bool:
+        """Immediately retrieve the first search result
+
+        :param query:
+        :type query: str
+        :param source:
+        :type source: str
+        :param media_type:
+        :type media_type: str
+        """
+        results = tuple(self.search(source, query, media_type, limit=1))
+        if len(results) > 0:
+            self.append(results[0])
+            return True
+        else:
+            return False
+
     def get_lastfm_playlist(self, url: str) -> Tuple[str, list]:
         """From a last.fm url, find the playlist title and tracks.
 


### PR DESCRIPTION
I wanted to make this a little bit more programmatic, so it could be used in scripts better. I noticed the search feature was fairly intelligent, so if you know exactly what you want via text, there's an excellent chance you need only hit enter. But for a script that needs to be automated and cannot have user input, this isn't feasible, and you'd need to get the Qobuz URL yourself to guarantee no interaction is needed.

The flag is "--first" or "-f". If there are formatting, naming, or other guideline issues, let me know!