### PR TITLE
Use default launcher if `vim` or `nvim` not found 

### DIFF
--- a/streamrip/rip/cli.py
+++ b/streamrip/rip/cli.py
@@ -222,8 +222,11 @@ def config_open(ctx, vim):
     if vim:
         if shutil.which("nvim") is not None:
             subprocess.run(["nvim", config_path])
-        else:
+        elif shutil.which("vim") is not None:
             subprocess.run(["vim", config_path])
+        else:
+            logger.error("Could not find nvim or vim. Using default launcher.")
+            click.launch(config_path)
     else:
         click.launch(config_path)
 


### PR DESCRIPTION
If the `--vim` option is selected in `rip config open` and vim or neovim are not found, the default launcher is used. Assists with issues such as #550 