### PR TITLE
Fix Tidal master quality

### DIFF
--- a/streamrip/client/downloadable.py
+++ b/streamrip/client/downloadable.py
@@ -200,7 +200,7 @@ class TidalDownloadable(Downloadable):
     ):
         self.session = session
         codec = codec.lower()
-        if codec == "flac":
+        if codec in ("flac", "mqa"):
             self.extension = "flac"
         else:
             self.extension = "m4a"


### PR DESCRIPTION
If a song attempts to download in "Master Quality Authenticated" through Tidal, the codec will be "mqa". In this case, it is contained as a FLAC and should be treated as such. Without the following changes, attempting to download an MQA will return the following error: `MP4StreamInfoError: not a MP4 file`. Simply adding the clause for "mqa" to equal `codec` resolves this.