### PR TITLE
Added path string validation

### DIFF
--- a/streamrip/metadata/album.py
+++ b/streamrip/metadata/album.py
@@ -7,6 +7,7 @@ from typing import Optional
 
 from .covers import Covers
 from .util import get_quality_id, safe_get, typed
+from ..filepath_utils import clean_filename
 
 PHON_COPYRIGHT = "\u2117"
 COPYRIGHT = "\u00a9"
@@ -67,27 +68,18 @@ class AlbumMetadata:
 
         none_str = "Unknown"
         info: dict[str, str | int | float] = {
-            "albumartist": self.validate_str(self.albumartist),
-            "albumcomposer": self.validate_str(self.albumcomposer) or none_str,
+            "albumartist": clean_filename(self.albumartist),
+            "albumcomposer": clean_filename(self.albumcomposer) or none_str,
             "bit_depth": self.info.bit_depth or none_str,
             "id": self.info.id,
             "sampling_rate": self.info.sampling_rate or none_str,
-            "title": self.validate_str(self.album),
+            "title": clean_filename(self.album),
             "year": self.year,
             "container": self.info.container,
         }
         
         return formatter.format(**info)
     
-    def validate_str(self, string) -> str:
-        # The OS will not correctly process the folders if special characters
-        # or trailing spaces are present
-
-        bad_chars = ['/', '\\', ':', '*', '?', '\"', '<', '>', '|']
-
-        valid_string = ''.join(i for i in string if not i in bad_chars).rstrip()
-        return valid_string
-
     @classmethod
     def from_qobuz(cls, resp: dict) -> AlbumMetadata:
         album = resp.get("title", "Unknown Album")

--- a/streamrip/metadata/album.py
+++ b/streamrip/metadata/album.py
@@ -63,19 +63,30 @@ class AlbumMetadata:
 
     def format_folder_path(self, formatter: str) -> str:
         # Available keys: "albumartist", "title", "year", "bit_depth", "sampling_rate",
-        # "id", and "albumcomposer",
+        # "id", and "albumcomposer",        
+
         none_str = "Unknown"
         info: dict[str, str | int | float] = {
-            "albumartist": self.albumartist,
-            "albumcomposer": self.albumcomposer or none_str,
+            "albumartist": self.validate_str(self.albumartist),
+            "albumcomposer": self.validate_str(self.albumcomposer) or none_str,
             "bit_depth": self.info.bit_depth or none_str,
             "id": self.info.id,
             "sampling_rate": self.info.sampling_rate or none_str,
-            "title": self.album,
+            "title": self.validate_str(self.album),
             "year": self.year,
             "container": self.info.container,
         }
+        
         return formatter.format(**info)
+    
+    def validate_str(self, string) -> str:
+        # The OS will not correctly process the folders if special characters
+        # or trailing spaces are present
+
+        bad_chars = ['/', '\\', ':', '*', '?', '\"', '<', '>', '|']
+
+        valid_string = ''.join(i for i in string if not i in bad_chars).rstrip()
+        return valid_string
 
     @classmethod
     def from_qobuz(cls, resp: dict) -> AlbumMetadata:


### PR DESCRIPTION
I ran into a couple of situations where streamrip would fail to process the data if the album or the artist included special characters (even one case where the record name had a random trailing empty space). 

The format I use is `folder_format = "{albumartist}/{year} - {title}"`, hence an album like `2024 - Cool Name ` (note trailing space) or `2024 - Hot / Cold` (special char) will fail the path creation, since it will try and create `C:/2024 - Cool Name /__artwork` (not valid, at least on Windows), or could try and split the path like `C:/2024 - Hot / Cold/__artwork`, and also fail in the process. 

The PR just adds a simple string validation to prevent any of those invalid characters, as well as trailing spaces.

Example record with [special character](https://www.qobuz.com/be-nl/album/novembre-vedrai-vedrai-iosonouncane/cl5cegghp8gsa)
Example record with [trailing space](https://www.qobuz.com/be-nl/album/qui-noi-cadiamo-verso-il-fondo-gelido-iosonouncane/yfpoii6r09lwb)