### PR TITLE
Fix lossless conversion bit depth issues

### DIFF
--- a/streamrip/converter.py
+++ b/streamrip/converter.py
@@ -121,27 +121,31 @@ class Converter:
             command.extend(self.ffmpeg_arg.split())
 
         if self.lossless:
-            if isinstance(self.sampling_rate, int):
-                sampling_rates = "|".join(
-                    str(rate) for rate in SAMPLING_RATES if rate <= self.sampling_rate
-                )
-                command.extend(["-af", f"aformat=sample_rates={sampling_rates}"])
+            aformat = []
 
+            if isinstance(self.sampling_rate, int):
+                sample_rates = "|".join(str(rate) for rate in SAMPLING_RATES if rate <= self.sampling_rate)
+                aformat.append(f"sample_rates={sample_rates}")
             elif self.sampling_rate is not None:
-                raise TypeError(
-                    f"Sampling rate must be int, not {type(self.sampling_rate)}",
-                )
+                raise TypeError(f"Sampling rate must be int, not {type(self.sampling_rate)}")
 
             if isinstance(self.bit_depth, int):
-                if int(self.bit_depth) == 16:
-                    command.extend(["-sample_fmt", "s16"])
-                elif int(self.bit_depth) in (24, 32):
-                    command.extend(["-sample_fmt", "s32p"])
-                else:
+                bit_depths = ["s16p", "s16"]
+
+                if self.bit_depth in (24, 32):
+                    bit_depths.extend(["s32p", "s32"])
+                elif self.bit_depth != 16:
                     raise ValueError("Bit depth must be 16, 24, or 32")
+
+                sample_fmts = "|".join(bit_depths)
+                aformat.append(f"sample_fmts={sample_fmts}")
             elif self.bit_depth is not None:
                 raise TypeError(f"Bit depth must be int, not {type(self.bit_depth)}")
 
+            if aformat:
+                aformat_params = ':'.join(aformat)
+                command.extend(["-af", f"aformat={aformat_params}"])
+    
         # automatically overwrite
         command.extend(["-y", self.tempfile])
 


### PR DESCRIPTION
When converting to a lossless codec, there are two issues relating to the bit depth:

- If the required bit depth is configured as 24, the file will always be converted to 24-bit, even if it's a 16-bit source file https://github.com/nathom/streamrip/issues/614;
- A required bit depth of 16 will break conversion to ALAC, and a bit depth of 24 will break conversion to FLAC, due to ALAC only supporting planar formats (but 16-bit conversion passes a non-planar format) and FLAC only supporting non-planar formats (but 24/32-bit conversion passes a planar format) https://github.com/nathom/streamrip/issues/615

This can be fixed by refactoring lossless conversion to always pass an `aformat` filter, containing sampling rate and/or bit depth (whereas previously only the sampling rate was in an `aformat` filter). This allows us to pass a list of bit depths; so not only can we specify both planar and non-planar formats (so ffmpeg can simply pick whichever applies to the specified codec), but if a list of bit depths is specified then ffmpeg won't use a bit depth higher than that of the source file.