### PR TITLE
Fix bug report template `-vvv` option

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -36,9 +36,9 @@ body:
     attributes:
       label: Debug Traceback
       description: |
-        Run your command, with `-vvv` appended to it, and paste the output here.
+        Run your command with the `-vvv` option and paste the output here.
         For example, if the problematic command was `rip url https://example.com`, then
-        you would run `rip url https://example.com -vvv` to get the debug logs.
+        you would run `rip -vvv url https://example.com` to get the debug logs.
         Make sure to check the logs for any personal information such as emails and remove them.
       render: "text"
       placeholder: Logs printed to terminal screen


### PR DESCRIPTION
The bug report template instructs users to append the `-vvv` option to get full debug logs. However as of v2 this now results in an error for some commands:
```
$ rip url https://example.com -vvv                                       
Usage: rip url [OPTIONS] URLS...
Try 'rip url --help' for help.

Error: No such option: -v
```
Instead the option should come directly after the `rip` command:
```
$ rip -vvv url https://example.com
[10:44:21] DEBUG    Showing all debug logs                                      cli.py:102
Found invalid url https://example.com, skipping.
           DEBUG    Removing dirs set()                                      artwork.py:19
```

The most straightforward way to fix this is to amend the template to direct users to put the option in the correct place.