### PR TITLE
Manually yield for better performance

### DIFF
--- a/streamrip/client/downloadable.py
+++ b/streamrip/client/downloadable.py
@@ -42,7 +42,7 @@ class Downloadable(ABC):
     session: aiohttp.ClientSession
     url: str
     extension: str
-    chunk_size = 2**17  # 1 MiB
+    chunk_size = 2**17
     _size: Optional[int] = None
 
     async def download(self, path: str, callback: Callable[[int], Any]):


### PR DESCRIPTION
Attempt to fix #601 

Profiling shows that kqueue.select is using most of the runtime. I suspect that it's because of all the async context switching happening in `_download`, which is triggering a select every time a chunk is received. This PR attempts a fix by using synchronous requests and manually yielding to the event loop.

`yield_every` and `chunk_size` may be tuned for better results.