### PR TITLE
Purge Deezloader comments and change Deezer error message (#432)

### DIFF
--- a/streamrip/client/deezer.py
+++ b/streamrip/client/deezer.py
@@ -168,9 +168,7 @@ class DeezerClient(Client):
             url = self.client.get_track_url(token, format_str)
         except deezer.WrongLicense:
             raise NonStreamableError(
-                "The requested quality is not available with your subscription. "
-                "Deezer HiFi is required for quality 2. Otherwise, the maximum "
-                "quality allowed is 1.",
+                f"The requested quality ({quality}) is not available with your subscription. Deezer HiFi is required for quality 2. Deezer Premium is required for quality 1. Otherwise, the maximum quality allowed is 0."
             )
         except deezer.WrongGeolocation:
             if not is_retry:

--- a/streamrip/client/downloadable.py
+++ b/streamrip/client/downloadable.py
@@ -101,7 +101,6 @@ class DeezerDownloadable(Downloadable):
         self.id = str(info["id"])
 
     async def _download(self, path: str, callback):
-        # with requests.Session().get(self.url, allow_redirects=True) as resp:
         async with self.session.get(self.url, allow_redirects=True) as resp:
             resp.raise_for_status()
             self._size = int(resp.headers.get("Content-Length", 0))
@@ -109,7 +108,6 @@ class DeezerDownloadable(Downloadable):
                 try:
                     info = await resp.json()
                     try:
-                        # Usually happens with deezloader downloads
                         raise NonStreamableError(f"{info['error']} - {info['message']}")
                     except KeyError:
                         raise NonStreamableError(info)

--- a/streamrip/config.py
+++ b/streamrip/config.py
@@ -57,15 +57,10 @@ class DeezerConfig:
     # for instructions on how to find this
     arl: str
     # 0, 1, or 2
-    # This only applies to paid Deezer subscriptions. Those using deezloader
-    # are automatically limited to quality = 1
+    # Unpaid accounts are limited to quality = 0.
+    # Quality 1 requires a Deezer Premium subscription,
+    # and quality 2 requires a Deezer HiFi subscription.
     quality: int
-    # This allows for free 320kbps MP3 downloads from Deezer
-    # If an arl is provided, deezloader is never used
-    use_deezloader: bool
-    # This warns you when the paid deezer account is not logged in and rip falls
-    # back to deezloader, which is unreliable
-    deezloader_warnings: bool
 
 
 @dataclass(slots=True)

--- a/streamrip/config.toml
+++ b/streamrip/config.toml
@@ -52,19 +52,14 @@ token_expiry = ""
 
 [deezer]
 # 0, 1, or 2
-# This only applies to paid Deezer subscriptions. Those using deezloader
-# are automatically limited to quality = 1
+# Unpaid accounts are limited to quality = 0.
+# Quality 1 requires a Deezer Premium subscription,
+# and quality 2 requires a Deezer HiFi subscription. 
 quality = 2
 # An authentication cookie that allows streamrip to use your Deezer account
 # See https://github.com/nathom/streamrip/wiki/Finding-Your-Deezer-ARL-Cookie
 # for instructions on how to find this
 arl = ""
-# This allows for free 320kbps MP3 downloads from Deezer
-# If an arl is provided, deezloader is never used
-use_deezloader = true
-# This warns you when the paid deezer account is not logged in and rip falls
-# back to deezloader, which is unreliable
-deezloader_warnings = true
 
 [soundcloud]
 # Only 0 is available for now

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -65,12 +65,7 @@ def test_sample_config_data_fields(sample_config_data):
             quality=3,
             download_videos=True,
         ),
-        deezer=DeezerConfig(
-            arl="testarl",
-            quality=2,
-            use_deezloader=True,
-            deezloader_warnings=True,
-        ),
+        deezer=DeezerConfig(arl="testarl", quality=2),
         soundcloud=SoundcloudConfig(
             client_id="clientid",
             app_version="appversion",

--- a/tests/test_config.toml
+++ b/tests/test_config.toml
@@ -52,19 +52,14 @@ token_expiry = "tokenexpiry"
 
 [deezer]
 # 0, 1, or 2
-# This only applies to paid Deezer subscriptions. Those using deezloader
-# are automatically limited to quality = 1
+# Unpaid accounts are limited to quality = 0.
+# Quality 1 requires a Deezer Premium subscription,
+# and quality 2 requires a Deezer HiFi subscription. 
 quality = 2
 # An authentication cookie that allows streamrip to use your Deezer account
 # See https://github.com/nathom/streamrip/wiki/Finding-Your-Deezer-ARL-Cookie
 # for instructions on how to find this
 arl = "testarl"
-# This allows for free 320kbps MP3 downloads from Deezer
-# If an arl is provided, deezloader is never used
-use_deezloader = true
-# This warns you when the paid deezer account is not logged in and rip falls
-# back to deezloader, which is unreliable
-deezloader_warnings = true
 
 [soundcloud]
 # Only 0 is available for now

--- a/tests/test_deezer_client.py
+++ b/tests/test_deezer_client.py
@@ -1,0 +1,42 @@
+import deezer
+import pytest
+
+from streamrip.client.deezer import DeezerClient
+from streamrip.config import Config
+from streamrip.exceptions import MissingCredentialsError, NonStreamableError
+from tests.util import arun
+
+
+def test_client_raises_missing_credentials():
+    c = Config.defaults()
+    with pytest.raises(MissingCredentialsError):
+        arun(DeezerClient(c).login())
+
+
+def test_get_downloadable_wrong_license(mocker):
+    config = Config.defaults()
+    free_client = DeezerClient(config)
+    quality = 2
+
+    def raise_wrong_license():
+        raise deezer.WrongLicense("")
+
+    mocker.patch.object(
+        free_client.client.gw,
+        "get_track",
+        lambda _: {
+            "FILESIZE_FLAC": "1234",
+            "TRACK_TOKEN": "foobar",
+        },
+    )
+    mocker.patch.object(
+        free_client.client,
+        "get_track_url",
+        lambda *args, **kwargs: raise_wrong_license(),
+    )
+
+    with pytest.raises(
+        NonStreamableError,
+        match=rf"The requested quality \({quality}\) is not available with your subscription. Deezer HiFi is required for quality 2. Deezer Premium is required for quality 1. Otherwise, the maximum quality allowed is 0.",
+    ):
+        arun(free_client.get_downloadable("foobar", quality))


### PR DESCRIPTION
Hi, this is my first commit here so bear with me :)

This addresses https://github.com/nathom/streamrip/issues/432 and removes everything related to deezloader from the config file (as I understand, `DeezloaderClient` was removed since https://dz.loaderapp.info/deezer is down, but the config wasn't updated).

Let me know there's any more changes required

Also, is this error handling still necessary? If not, I can remove it as well.
https://github.com/nathom/streamrip/compare/dev...owhyy:streamrip:dev#diff-cf669bae32b2c226598f7afe919ed2ef8188c93e63063b49a7f6cb0f17e9e26bL111-L115