### PR TITLE
Update album.py

### DIFF
--- a/streamrip/metadata/album.py
+++ b/streamrip/metadata/album.py
@@ -383,7 +383,7 @@ class AlbumMetadata:
         else:
             year = "Unknown Year"
 
-        _copyright = typed(resp.get("copyright"), str)
+        _copyright = typed(resp.get("copyright"), str | None)
         artists = typed(resp.get("artists", []), list)
         albumartist = ", ".join(a["name"] for a in artists)
         if not albumartist:


### PR DESCRIPTION
Apparently some Tidal tracks don't have a copyright field so streamrip crashes when you hit them. This patch acknowledges that that field can be nullable.