### PR TITLE
Fixed issues with description in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,9 +33,9 @@ When you type
 rip
 ```
 
-it should show the main help page. If you have no idea what these mean, or are having other issues installing, check out the [detailed installation instructions](https://github.com/nathom/streamrip/wiki#detailed-installation-instructions).  
+it should show the main help page. If you have no idea what these mean, or are having other issues installing, check out the [detailed installation instructions](https://github.com/nathom/streamrip/wiki#detailed-installation-instructions).
 
-For Arch Linux users, an AUR package exists. Make sure to install required packages from the AUR before using `makepkg` or use an AUR helper to automatically resolve them.  
+For Arch Linux users, an AUR package exists. Make sure to install required packages from the AUR before using `makepkg` or use an AUR helper to automatically resolve them.
 ```
 git clone https://aur.archlinux.org/streamrip.git
 cd streamrip
@@ -45,7 +45,6 @@ makepkg -si
  ```
 paru -S streamrip
 ```
-
 
 ### Streamrip beta
 
@@ -72,17 +71,13 @@ Download multiple albums from Qobuz
 rip url https://www.qobuz.com/us-en/album/back-in-black-ac-dc/0886444889841 https://www.qobuz.com/us-en/album/blue-train-john-coltrane/0060253764852
 ```
 
-
-
 Download the album and convert it to `mp3`
 
 ```bash
-rip url --codec=MP3 https://open.qobuz.com/album/0060253780968
+rip --codec mp3 url https://open.qobuz.com/album/0060253780968
 ```
 
-
-
-To set the maximum quality, use the `--max-quality` option to `0, 1, 2, 3, 4`:
+To set the maximum quality, use the `--quality` option to `0, 1, 2, 3, 4`:
 
 | Quality ID | Audio Quality         | Available Sources                            |
 | ---------- | --------------------- | -------------------------------------------- |
@@ -92,14 +87,13 @@ To set the maximum quality, use the `--max-quality` option to `0, 1, 2, 3, 4`:
 | 3          | 24 bit, ≤ 96 kHz      | Tidal (MQA), Qobuz, SoundCloud (rarely)      |
 | 4          | 24 bit, ≤ 192 kHz     | Qobuz                                        |
 
-
 ```bash
-rip url --max-quality=3 https://tidal.com/browse/album/147569387
+rip --quality 3 url https://tidal.com/browse/album/147569387
 ```
 
-> Using `4` is generally a waste of space. It is impossible for humans to perceive the between sampling rates higher than 44.1 kHz. It may be useful if you're processing/slowing down the audio.
+> Using `4` is generally a waste of space. It is impossible for humans to perceive the difference between sampling rates higher than 44.1 kHz. It may be useful if you're processing/slowing down the audio.
 
-Search for albums matching `lil uzi vert` on SoundCloud
+Search for playlists matching `rap` on Tidal
 
 ```bash
 rip search tidal playlist 'rap'
@@ -125,9 +119,7 @@ For more customization, see the config file
 rip config open
 ```
 
-
-
-If you're confused about anything, see the help pages. The main help pages can be accessed by typing `rip` by itself in the command line. The help pages for each command can be accessed with the `-help` flag. For example, to see the help page for the `url` command, type
+If you're confused about anything, see the help pages. The main help pages can be accessed by typing `rip` by itself in the command line. The help pages for each command can be accessed with the `--help` flag. For example, to see the help page for the `url` command, type
 
 ```
 rip url --help
@@ -138,7 +130,6 @@ rip url --help
 ## Other information
 
 For more in-depth information about `streamrip`, see the help pages and the [wiki](https://github.com/nathom/streamrip/wiki/).
-
 
 ## Contributions
 
@@ -164,7 +155,7 @@ Please document any functions or obscure lines of code.
 
 ### The Wiki
 
-To help out `streamrip` users that may be having trouble, consider contributing some information to the wiki. 
+To help out `streamrip` users that may be having trouble, consider contributing some information to the wiki.
 Nothing is too obvious and everything is appreciated.
 
 ## Acknowledgements
@@ -177,8 +168,6 @@ Thanks to Vitiko98, Sorrow446, and DashLt for their contributions to this projec
 - [Qo-DL Reborn](https://github.com/badumbass/Qo-DL-Reborn)
 - [Tidal-Media-Downloader](https://github.com/yaronzz/Tidal-Media-Downloader)
 - [scdl](https://github.com/flyingrub/scdl)
-
-
 
 ## Disclaimer
 


### PR DESCRIPTION
I've put parameters for `quality` and `codec` to where they work in the current `rip` command, right after the main command itself.
If it's inteded so they go after `url` command in the future, close the PR please.
But it should reflect the current tool state I think, it's confusing for new users that refer to examples in this document.

Also organized paragraphs so they have 1 line of separation only, if it's not an problem.