### PR TITLE
Disable aiohttp client timeout

### DIFF
--- a/streamrip/client/client.py
+++ b/streamrip/client/client.py
@@ -53,6 +53,7 @@ class Client(ABC):
         if headers is None:
             headers = {}
         return aiohttp.ClientSession(
+            timeout=aiohttp.ClientTimeout(total=0),
             headers={"User-Agent": DEFAULT_USER_AGENT},
             **headers,
         )


### PR DESCRIPTION
A fix for `RuntimeWarning: coroutine 'Artist._download_async.<locals>._rip' was never awaited` error message

Potentially fixes: https://github.com/nathom/streamrip/issues/555, https://github.com/nathom/streamrip/issues/580, https://github.com/nathom/streamrip/issues/645