### PR TITLE
Deezer alternative track

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ StreamripDownloads
 /.mypy_cache
 .DS_Store
 pyrightconfig.json
+.vscode

--- a/streamrip/client/deezer.py
+++ b/streamrip/client/deezer.py
@@ -71,7 +71,7 @@ class DeezerClient(Client):
             raise NonStreamableError(e)
 
         # If not readable (wrong zone, track id not available anymore etc.)
-        if item["readable"] == False:
+        if not item["readable"]:
             try:
                 if ("alternative" in item):
                     logger.warning(f"Original track id {item_id} not readable, using alternative {item['d']}")

--- a/streamrip/media/playlist.py
+++ b/streamrip/media/playlist.py
@@ -50,7 +50,8 @@ class PendingPlaylistTrack(Pending):
         except NonStreamableError as e:
             logger.error(f"Could not stream track {self.id}: {e}")
             return None
-
+        # in case of alternative song downloaded
+        self.id = resp["id"]
         album = AlbumMetadata.from_track_resp(resp, self.client.source)
         if album is None:
             logger.error(

--- a/streamrip/media/playlist.py
+++ b/streamrip/media/playlist.py
@@ -50,7 +50,7 @@ class PendingPlaylistTrack(Pending):
         except NonStreamableError as e:
             logger.error(f"Could not stream track {self.id}: {e}")
             return None
-        # in case of alternative song downloaded
+        # in case of alternative song downloaded, update the track id
         self.id = resp["id"]
         album = AlbumMetadata.from_track_resp(resp, self.client.source)
         if album is None:


### PR DESCRIPTION
Track IDs on deezer are updated quite frequently, because of some obscure track duplication. And the old version is not playable anymore. When you listen to a playlist, it contains the old identifiers, but you don't notice because the deezer interface manages to retrieve the new track version anyway.

But when streamrip retrieves the track list from a playlist, it ends up with the wrong identifiers.

This PR covers the modifications made to get around the problem (#638), in the following order of preference:
- use the “Alternative” field sometimes provided by deezer, when a new track is correctly linked from the old version.
- use a search on album title, artist name and track name.

During this process, log messages are sent to the console (WARNING if alternative found, ERROR if no alternative is found).