### PR TITLE
Skipping tracks on any NonStreamableError when getting downloadable info (#645)

### DIFF
--- a/streamrip/client/deezer.py
+++ b/streamrip/client/deezer.py
@@ -173,7 +173,7 @@ class DeezerClient(Client):
                 "quality allowed is 1.",
             )
         except deezer.WrongGeolocation:
-            if not is_retry:
+            if not is_retry and fallback_id:
                 return await self.get_downloadable(fallback_id, quality, is_retry=True)
             raise NonStreamableError(
                 "The requested track is not available. This may be due to your country/location.",

--- a/streamrip/media/track.py
+++ b/streamrip/media/track.py
@@ -138,7 +138,7 @@ class PendingTrack(Pending):
         try:
             meta = TrackMetadata.from_resp(self.album, source, resp)
         except Exception as e:
-            logger.error(f"Error building track metadata for {id=}: {e}")
+            logger.error(f"Error building track metadata for {self.id}: {e}")
             return None
 
         if meta is None:
@@ -147,7 +147,11 @@ class PendingTrack(Pending):
             return None
 
         quality = self.config.session.get_source(source).quality
-        downloadable = await self.client.get_downloadable(self.id, quality)
+        try:
+            downloadable = await self.client.get_downloadable(self.id, quality)
+        except NonStreamableError as e:
+            logger.error(f'Error getting downloadable data for track {meta.tracknumber} [{self.id}]: {e}')
+            return None
 
         downloads_config = self.config.session.downloads
         if downloads_config.disc_subdirectories and self.album.disctotal > 1:

--- a/streamrip/media/track.py
+++ b/streamrip/media/track.py
@@ -150,7 +150,9 @@ class PendingTrack(Pending):
         try:
             downloadable = await self.client.get_downloadable(self.id, quality)
         except NonStreamableError as e:
-            logger.error(f'Error getting downloadable data for track {meta.tracknumber} [{self.id}]: {e}')
+            logger.error(
+                f"Error getting downloadable data for track {meta.tracknumber} [{self.id}]: {e}"
+            )
             return None
 
         downloads_config = self.config.session.downloads


### PR DESCRIPTION
Skipping tracks on any NonStreamableError when getting downloadable info (#645)
Based on the linked issue, also added check for fallback_id as it was empty and didn't result in a correct final error.

I added the generic `NonStreamableError` catch as I think a track should be skipped on any reason for that exception, letting other possibly healthy tracks to be processed.

The `WrongGeolocation` Deezer exception from the linked album in the link affects only 2 tracks, so those cannot be downloaded. But others can.