### PR TITLE
Added album version data to album search selection

### DIFF
--- a/streamrip/metadata/search_results.py
+++ b/streamrip/metadata/search_results.py
@@ -128,7 +128,9 @@ class AlbumSummary(Summary):
     @classmethod
     def from_item(cls, item: dict):
         id = str(item["id"])
-        name = item.get("title") or "Unknown Title"
+        title = (item.get("title") or "").strip()
+        version = (item.get("version") or "").strip()
+        name = title + (" (" + version + ")" if version else "")
         artist = (
             item.get("performer", {}).get("name")
             or item.get("artist", {}).get("name")


### PR DESCRIPTION
I found it helpful to see the type of album being downloaded whether a remastered/deluxe/...etc. This will append it to the title string if there is data for a version. Added the .strip() to clean up whitespace.

<img width="536" alt="image" src="https://github.com/user-attachments/assets/97d19fc8-06cb-4e02-9ec1-66a246aa24b3">
