### PR TITLE
Fix for Playlists looking good in Navidrome via compilation-tag

### DIFF
--- a/streamrip/media/playlist.py
+++ b/streamrip/media/playlist.py
@@ -65,12 +65,15 @@ class PendingPlaylistTrack(Pending):
             )
             self.db.set_failed(self.client.source, "track", self.id)
             return None
-
+            
+        meta.compilation = 1
         c = self.config.session.metadata
         if c.renumber_playlist_tracks:
             meta.tracknumber = self.position
         if c.set_playlist_to_album:
             album.album = self.playlist_name
+            album.albumartist = "Playlist"
+
 
         quality = self.config.session.get_source(self.client.source).quality
         try:

--- a/streamrip/metadata/tagger.py
+++ b/streamrip/metadata/tagger.py
@@ -182,6 +182,7 @@ class Container(Enum):
             "tracknumber",
             "discnumber",
             "composer",
+            "compilation",
             "isrc",
         }
         if attr in in_trackmetadata:

--- a/streamrip/metadata/track.py
+++ b/streamrip/metadata/track.py
@@ -31,6 +31,7 @@ class TrackMetadata:
     tracknumber: int
     discnumber: int
     composer: str | None
+    compilation: int = 0
     isrc: str | None = None
 
     @classmethod
@@ -208,6 +209,7 @@ class TrackMetadata:
             tracknumber=tracknumber,
             discnumber=discnumber,
             composer=None,
+            compilation=0,
             isrc=isrc,
         )
 


### PR DESCRIPTION
In navidrome the downloaded playlists are looking bad as they are splitted in several albums with one track in them.
So here changes for my scenario of downloading from tidal and let playlists look good in navidrome by setting the "compilation tag" for flac files (havent tested if its working with other than flac).
Also the Albuminterpret is changed to "Playlist" as it looks good in navidrome and these "playlis-albums" are good to find like that i think.

In my scenario its working but im not a coder and so there might be better ways to do what i have done.
But eventually it can help someone. 

![image](https://github.com/user-attachments/assets/83da9ef4-46ee-4e5d-bf4d-1894122bf2f9)
