### PR TITLE
Fixes unguarded remove from list (closes #752)

### DIFF
--- a/streamrip/client/qobuz.py
+++ b/streamrip/client/qobuz.py
@@ -117,7 +117,8 @@ class QobuzSpoofer:
             ).decode("utf-8")
 
         vals: List[str] = list(secrets.values())
-        vals.remove("")
+        while "" in vals:
+            vals.remove("")
 
         secrets_list = vals
 


### PR DESCRIPTION
When fetching app secrets, the removal of empty strings is unguarded, resulting in a ValueError when the empty string is not in the fetched list of secrets.

The while ensures that if for some reason the secrets list has multiple empty strings, they get removed.
This pull request fixes #752.