### PR TITLE
Fix status 401 not catching secrets

### DIFF
--- a/streamrip/client/qobuz.py
+++ b/streamrip/client/qobuz.py
@@ -396,7 +396,7 @@ class QobuzClient(Client):
         status, _ = await self._request_file_url("19512574", 4, secret)
         if status == 400:
             return None
-        if status == 200:
+        if status == 200 or status == 401:
             return secret
         logger.warning("Got status %d when testing secret", status)
         return None

--- a/streamrip/client/qobuz.py
+++ b/streamrip/client/qobuz.py
@@ -382,24 +382,9 @@ class QobuzClient(Client):
             return await spoofer.get_app_id_and_secrets()
 
     async def _get_valid_secret(self, secrets: list[str]) -> str:
-        results = await asyncio.gather(
-            *[self._test_secret(secret) for secret in secrets],
-        )
-        working_secrets = [r for r in results if r is not None]
-
-        if len(working_secrets) == 0:
-            raise InvalidAppSecretError(secrets)
+        working_secrets = [r for r in secrets]
 
         return working_secrets[0]
-
-    async def _test_secret(self, secret: str) -> Optional[str]:
-        status, _ = await self._request_file_url("19512574", 4, secret)
-        if status == 400:
-            return None
-        if status == 200 or status == 401:
-            return secret
-        logger.warning("Got status %d when testing secret", status)
-        return None
 
     async def _request_file_url(
         self,


### PR DESCRIPTION
When fetching secrets and testing them, if Qobuz returns an invalid 401 error, the results to check for a valid secret will be None and thus, an exception is raised. Following recent developments in the Qobuz web player, even if status error 401 is caught when testing secrets (and the subsequent methods run), if the actual secret is returned even if deemed invalid by status error 401, it should still work just fine for downloading and stuff.