### PR TITLE
Fix error when fetch app_id and/or secrets: ValueError: list.remove(x): x not in list (fix #751 #767 #752)

### DIFF
--- a/streamrip/client/qobuz.py
+++ b/streamrip/client/qobuz.py
@@ -117,7 +117,8 @@ class QobuzSpoofer:
             ).decode("utf-8")
 
         vals: List[str] = list(secrets.values())
-        vals.remove("")
+        if "" in vals:
+            vals.remove("")
 
         secrets_list = vals
 


### PR DESCRIPTION
fix https://github.com/nathom/streamrip/issues/751
fix #752 
fix https://github.com/nathom/streamrip/issues/767

Fix error when fetch app_id and/or secrets:
ValueError: list.remove(x): x not in list

Try to fix this error by check if vals contains empty string:

```python
        if "" in vals:
            vals.remove("")
```