### PR TITLE
Fix aiodns

### DIFF
--- a/streamrip/rip/main.py
+++ b/streamrip/rip/main.py
@@ -27,6 +27,8 @@ from .prompter import get_prompter
 
 logger = logging.getLogger("streamrip")
 
+if platform.system() == "Windows":
+	asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
 
 class Main:
     """Provides all of the functionality called into by the CLI.


### PR DESCRIPTION
### Issue

Critical error with aiodns on Windows, preventing Streamrip from functioning. Issue #816

### Solution

Fixes this issue, works fine for me on Windows 11