### PR TITLE
Resolve duplicate download folder names in download path

### DIFF
--- a/streamrip/media/track.py
+++ b/streamrip/media/track.py
@@ -228,7 +228,7 @@ class PendingSingle(Pending):
         assert isinstance(quality, int)
         parent = config.downloads.folder
         if config.filepaths.add_singles_to_folder:
-            folder = os.path.join(parent, self._format_folder(album))
+            folder = self._format_folder(album)
         else:
             folder = parent
 


### PR DESCRIPTION
**Issue**
I have enabled `add_singles_to_folder` and set the download path to a directory and not a path, and because of the duplicated `os.path.join`, the directory name gets repeated.
Instead of it be like `directory/folder_format/track_format`, it will be `directory/directory/folder_format/track_format`.

**Solution**
Remove the duplicated `os.path.join`.