### PR TITLE
Use semicolon as default album artist separator

### DIFF
--- a/streamrip/metadata/album.py
+++ b/streamrip/metadata/album.py
@@ -304,7 +304,7 @@ class AlbumMetadata:
         _copyright = typed(resp.get("copyright", ""), str)
 
         artists = typed(resp.get("artists", []), list)
-        albumartist = ", ".join(a["name"] for a in artists)
+        albumartist = "; ".join(a["name"] for a in artists)
         if not albumartist:
             albumartist = typed(safe_get(resp, "artist", "name", default=""), str)
 


### PR DESCRIPTION
This change updates the artist separator in metadata tags from `","` to `";"`. Using a comma for joined artist names results in the full string being treated as one literal artist in many media players and library systems. 

This change brings metadata output in line with widely-used tagging conventions (Subsconic/Navidrome, Jellyfin, Plex, etc.)