### PR TITLE
Include all artists in Deezer

### DIFF
--- a/streamrip/metadata/album.py
+++ b/streamrip/metadata/album.py
@@ -169,7 +169,9 @@ class AlbumMetadata:
         year = date[:4]
         _copyright = None
         description = None
-        albumartist = typed(safe_get(resp, "artist", "name"), str)
+        albumartist = ", ".join(
+            c["name"] for c in resp["contributors"] if c["type"] == "artist"
+        )
         albumcomposer = None
         label = resp.get("label")
         booklets = None

--- a/streamrip/metadata/track.py
+++ b/streamrip/metadata/track.py
@@ -95,7 +95,9 @@ class TrackMetadata:
         explicit = typed(resp["explicit_lyrics"], bool)
         work = None
         title = typed(resp["title"], str)
-        artist = typed(resp["artist"]["name"], str)
+        artist = ", ".join(
+            c["name"] for c in resp["contributors"] if c["type"] == "artist"
+        )
         tracknumber = typed(resp["track_position"], int)
         discnumber = typed(resp["disk_number"], int)
         composer = None


### PR DESCRIPTION
**Issue**
The current way of handling the Deezer's metadata only includes the first artist as the album and track's artist.

**Solution**
Loop through contributors to have all the artists.