### PR TITLE
fix tidal /u suffix in url messes with the regex

### DIFF
--- a/streamrip/rip/parse_url.py
+++ b/streamrip/rip/parse_url.py
@@ -54,6 +54,10 @@ class URL(ABC):
 class GenericURL(URL):
     @classmethod
     def from_str(cls, url: str) -> URL | None:
+        # tidal.com/track/123/u messes with the regex
+        if "tidal.com" in url and url.endswith("/u"):
+            url = url.rstrip("/u")
+
         generic_url = URL_REGEX.match(url)
         if generic_url is None:
             return None

--- a/tests/test_parse_url.py
+++ b/tests/test_parse_url.py
@@ -51,6 +51,18 @@ class TestParseURL(unittest.TestCase):
         self.assertEqual(groups[1], "track")  # media_type
         self.assertEqual(groups[2], "3083287")  # item_id
 
+        _test = lambda u: parse_url(u).match.groups()
+
+        self.assertEqual(
+            _test("https://tidal.com/track/144921990/u"),
+            ("tidal", "track", "144921990"),
+        )
+
+        self.assertEqual(
+            _test("https://tidal.com/track/454879903?u"),
+            ("tidal", "track", "454879903"),
+        )
+
     def test_deezer_track_url(self):
         """Test that Deezer track URLs are matched correctly."""
         url = "https://www.deezer.com/track/4195713"


### PR DESCRIPTION
fixes gh-910

added test cases and confirmed it works, along running all test cases to confirm no regressions

I was thinking first to make the parsing better and split the regex by using `urlparse` but I don't think it's worth it

open to suggestions

```
❯ python -m unittest discover -s tests
.........
----------------------------------------------------------------------
Ran 9 tests in 0.001s

OK
```