### PR TITLE
feat(track): add id field to formatter

### DIFF
--- a/streamrip/config.toml
+++ b/streamrip/config.toml
@@ -166,7 +166,7 @@ add_singles_to_folder = false
 # Available keys: "albumartist", "title", "year", "bit_depth", "sampling_rate",
 # "id", and "albumcomposer"
 folder_format = "{albumartist} - {title} ({year}) [{container}] [{bit_depth}B-{sampling_rate}kHz]"
-# Available keys: "tracknumber", "artist", "albumartist", "composer", "title",
+# Available keys: "id", "tracknumber", "artist", "albumartist", "composer", "title",
 # and "albumcomposer", "explicit"
 track_format = "{tracknumber:02}. {artist} - {title}{explicit}"
 # Only allow printable ASCII characters in filenames.

--- a/streamrip/metadata/track.py
+++ b/streamrip/metadata/track.py
@@ -232,6 +232,7 @@ class TrackMetadata:
         # and "explicit", "albumcomposer"
         none_text = "Unknown"
         info = {
+            "id": self.info.id,
             "title": self.title,
             "tracknumber": self.tracknumber,
             "artist": self.artist,


### PR DESCRIPTION
This commit introduces the feature to use the id field in the track format.

Tested locally successfully