### PR TITLE
Fix Tidal device authorization by updating client credentials

### DIFF
--- a/streamrip/client/tidal.py
+++ b/streamrip/client/tidal.py
@@ -18,9 +18,9 @@ logger = logging.getLogger("streamrip")
 BASE = "https://api.tidalhifi.com/v1"
 AUTH_URL = "https://auth.tidal.com/v1/oauth2"
 
-CLIENT_ID = base64.b64decode("elU0WEhWVmtjMnREUG80dA==").decode("iso-8859-1")
+CLIENT_ID = base64.b64decode("ZlgySnhkbW50WldLMGl4VA==").decode("iso-8859-1")
 CLIENT_SECRET = base64.b64decode(
-    "VkpLaERGcUpQcXZzUFZOQlY2dWtYVEptd2x2YnR0UDd3bE1scmM3MnNlND0=",
+    "MU5tNUFmREFqeHJnSkZKYktOV0xlQXlLR1ZHbUlOdVhQUExIVlhBdnhBZz0=",
 ).decode("iso-8859-1")
 AUTH = aiohttp.BasicAuth(login=CLIENT_ID, password=CLIENT_SECRET)
 STREAM_URL_REGEX = re.compile(


### PR DESCRIPTION
Fixes #929

Tidal device authorization was failing with invalid_client errors due to outdated client credentials.

This PR updates the credentials to restore Tidal login and downloading functionality.

Tested on MacOS with the latest release by successfully authenticating with Tidal and downloading albums and playlists.

Related issues: #897, #899, #906, #925