### PR TITLE
Respect configured lossy conversion bitrate

### DIFF
--- a/streamrip/converter.py
+++ b/streamrip/converter.py
@@ -167,6 +167,10 @@ class Converter:
             self.ffmpeg_arg = self.default_ffmpeg_arg
             return
 
+    @classmethod
+    def get_quality_arg(cls, _: int) -> str:
+        return cls.default_ffmpeg_arg
+
 
 class FLAC(Converter):
     """Class for FLAC converter."""
@@ -205,8 +209,9 @@ class LAME(Converter):
     container = "mp3"
     default_ffmpeg_arg = "-q:a 0"  # V0
 
-    def get_quality_arg(self, rate):
-        return self._bitrate_map[rate]
+    @classmethod
+    def get_quality_arg(cls, rate):
+        return cls._bitrate_map.get(rate, f"-b:a {rate}k")
 
 
 class ALAC(Converter):
@@ -232,8 +237,9 @@ class Vorbis(Converter):
     container = "ogg"
     default_ffmpeg_arg = "-q:a 6"  # 160, aka the "high" quality profile from Spotify
 
-    def get_quality_arg(self, rate: int) -> str:
-        arg = "qscale:a %d"
+    @classmethod
+    def get_quality_arg(cls, rate: int) -> str:
+        arg = "-qscale:a %d"
         if rate <= 128:
             return arg % (rate / 16 - 4)
         if rate <= 256:
@@ -256,8 +262,9 @@ class OPUS(Converter):
     container = "opus"
     default_ffmpeg_arg = "-b:a 128k"  # Transparent
 
-    def get_quality_arg(self, _: int) -> str:
-        return ""
+    @classmethod
+    def get_quality_arg(cls, rate: int) -> str:
+        return f"-b:a {rate}k"
 
 
 class AAC(Converter):
@@ -274,8 +281,9 @@ class AAC(Converter):
     container = "m4a"
     default_ffmpeg_arg = "-b:a 256k"
 
-    def get_quality_arg(self, _: int) -> str:
-        return ""
+    @classmethod
+    def get_quality_arg(cls, rate: int) -> str:
+        return f"-b:a {rate}k"
 
 
 def get(codec: str) -> type[Converter]:

--- a/streamrip/media/track.py
+++ b/streamrip/media/track.py
@@ -85,8 +85,13 @@ class Track(Media):
     async def _convert(self):
         c = self.config.session.conversion
         engine_class = converter.get(c.codec)
+        ffmpeg_arg = None
+        if not engine_class.lossless:
+            ffmpeg_arg = engine_class.get_quality_arg(c.lossy_bitrate)
+
         engine = engine_class(
             filename=self.download_path,
+            ffmpeg_arg=ffmpeg_arg,
             sampling_rate=c.sampling_rate,
             bit_depth=c.bit_depth,
             remove_source=True,  # always going to delete the old file

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -1,0 +1,71 @@
+from util import arun
+
+from streamrip import converter
+from streamrip.config import Config
+from streamrip.media.track import Track
+
+
+class DummyConverter:
+    lossless = False
+    instances = []
+
+    @classmethod
+    def get_quality_arg(cls, rate):
+        return f"-b:a {rate}k"
+
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+        self.final_fn = "/tmp/output.opus"
+        self.instances.append(self)
+
+    async def convert(self):
+        pass
+
+
+class DummyLosslessConverter(DummyConverter):
+    lossless = True
+    instances = []
+
+    @classmethod
+    def get_quality_arg(cls, rate):
+        raise AssertionError("lossless converters should not use lossy_bitrate")
+
+
+def test_lossy_bitrate_config_is_passed_to_converter(monkeypatch):
+    monkeypatch.setattr("streamrip.media.track.converter.get", lambda _: DummyConverter)
+    DummyConverter.instances = []
+
+    config = Config.defaults()
+    config.session.conversion.codec = "OPUS"
+    config.session.conversion.lossy_bitrate = 160
+    track = Track(None, None, config, "", None, None, download_path="/tmp/source.flac")
+
+    arun(track._convert())
+
+    engine = DummyConverter.instances[0]
+    assert engine.kwargs["ffmpeg_arg"] == "-b:a 160k"
+    assert track.download_path == "/tmp/output.opus"
+
+
+def test_lossy_bitrate_config_is_not_passed_to_lossless_converter(monkeypatch):
+    monkeypatch.setattr(
+        "streamrip.media.track.converter.get", lambda _: DummyLosslessConverter
+    )
+    DummyLosslessConverter.instances = []
+
+    config = Config.defaults()
+    config.session.conversion.codec = "ALAC"
+    config.session.conversion.lossy_bitrate = 160
+    track = Track(None, None, config, "", None, None, download_path="/tmp/source.flac")
+
+    arun(track._convert())
+
+    engine = DummyLosslessConverter.instances[0]
+    assert engine.kwargs["ffmpeg_arg"] is None
+
+
+def test_lossy_codec_quality_args_use_configured_bitrate():
+    assert converter.OPUS.get_quality_arg(160) == "-b:a 160k"
+    assert converter.AAC.get_quality_arg(192) == "-b:a 192k"
+    assert converter.LAME.get_quality_arg(160) == "-b:a 160k"
+    assert converter.Vorbis.get_quality_arg(160) == "-qscale:a 5"


### PR DESCRIPTION
## Problem
When conversion is configured for OPUS with `lossy_bitrate = 160`, streamrip still passes the codec default bitrate to ffmpeg.

Reproduction:
1. Set conversion to OPUS and `lossy_bitrate = 160` in the config.
2. Run `rip -vv <url>`.
3. The debug output currently reports `FFmpeg codec extra argument: -b:a 128k`, and the generated ffmpeg command contains `-b:a 128k` instead of the configured `-b:a 160k`.

## Summary
- pass `conversion.lossy_bitrate` into lossy converters during track conversion
- make OPUS and AAC generate bitrate ffmpeg args from the configured value
- add conversion tests covering lossy and lossless converter behavior

## Tests
- `python -m pytest`
- `python -m black --check streamrip/converter.py streamrip/media/track.py tests/test_converter.py`

Note: `ruff` is not installed in the local environment, so `ruff check` could not be run here.
