### PR TITLE
fix-962 | remove listen subnet from tidal url for querying lyrics

### DIFF
--- a/streamrip/client/tidal.py
+++ b/streamrip/client/tidal.py
@@ -113,7 +113,7 @@ class TidalClient(Client):
         elif media_type == "track":
             try:
                 resp = await self._api_request(
-                    f"tracks/{item_id!s}/lyrics", base="https://listen.tidal.com/v1"
+                    f"tracks/{item_id!s}/lyrics", base="https://tidal.com/v1"
                 )
 
                 # Use unsynced lyrics for MP3, synced for others (FLAC, OPUS, etc)


### PR DESCRIPTION
Calling `listen.tidal.com` provides a redirect to `tidal.com`, which aiohttp then does not attach headers to automatically.
This is a naive solution to this problem - just don't use the subnet. Alternatively, we could update the get function to attach headers to redirects manually instead of relying on aiohttp.