### PR TITLE
fix(deezer): use internal gw API for playlist fetching

### DIFF
--- a/streamrip/client/deezer.py
+++ b/streamrip/client/deezer.py
@@ -99,12 +99,15 @@ class DeezerClient(Client):
 
     async def get_playlist(self, item_id: str) -> dict:
         pl_metadata, pl_tracks = await asyncio.gather(
-            asyncio.to_thread(self.client.api.get_playlist, item_id),
-            asyncio.to_thread(self.client.api.get_playlist_tracks, item_id),
+            asyncio.to_thread(self.client.gw.get_playlist, item_id),
+            asyncio.to_thread(self.client.gw.get_playlist_tracks, item_id),
         )
-        pl_metadata["tracks"] = pl_tracks["data"]
-        pl_metadata["track_total"] = len(pl_tracks["data"])
-        return pl_metadata
+        # Normalize gw response to match api structure
+        tracks = pl_tracks if isinstance(pl_tracks, list) else pl_tracks["data"]
+        return {
+            "title": pl_metadata["DATA"]["TITLE"],
+            "tracks": [{"id": t["SNG_ID"]} for t in tracks],
+        }
 
     async def get_artist(self, item_id: str) -> dict:
         artist, albums = await asyncio.gather(
@@ -161,7 +164,7 @@ class DeezerClient(Client):
             int(track_info.get(f"FILESIZE_{format}", 0)) for _, format in quality_map
         ]
         dl_info["quality_to_size"] = size_map
-        
+
         # Check if requested quality is available
         if size_map[quality] == 0:
             if self.config.lower_quality_if_not_available:
@@ -178,7 +181,7 @@ class DeezerClient(Client):
                 raise NonStreamableError(
                     f"The requested quality {quality} is not available and fallback is disabled."
                 )
-        
+
         # Update the quality in dl_info to reflect the final quality used
         dl_info["quality"] = quality
 

--- a/streamrip/filepath_utils.py
+++ b/streamrip/filepath_utils.py
@@ -13,6 +13,7 @@ def truncate_str(text: str) -> str:
 
 
 def clean_filename(fn: str, restrict: bool = False) -> str:
+    fn = fn.replace("/", "-")
     path = truncate_str(str(sanitize_filename(fn)))
     if restrict:
         path = "".join(c for c in path if c in ALLOWED_CHARS)
@@ -21,6 +22,7 @@ def clean_filename(fn: str, restrict: bool = False) -> str:
 
 
 def clean_filepath(fn: str, restrict: bool = False) -> str:
+    fn = fn.replace("/", "-")
     path = str(sanitize_filepath(fn))
     if restrict:
         path = "".join(c for c in path if c in ALLOWED_CHARS)


### PR DESCRIPTION
## Problem

The public REST API (api.deezer.com) now returns PermissionException (code 200) for playlist requests, making playlist downloads impossible.

## Fix

Switching to the internal gw API which uses the ARL cookie already present after login fixes the issue.

Changes:
- `client/deezer.py`: switch `get_playlist()` from `api` to `gw` endpoints and normalize the gw response structure in the client layer before passing upstream
- `filepath_utils.py`: replace `/` in filenames and folder names to prevent unwanted subdirectories being created

## Tested

Tested with a Deezer playlist, downloads complete successfully.