### PR TITLE
fix: handle null copyright field in Tidal track response

### DIFF
--- a/streamrip/metadata/album.py
+++ b/streamrip/metadata/album.py
@@ -384,7 +384,7 @@ class AlbumMetadata:
         else:
             year = "Unknown Year"
 
-        _copyright = typed(resp.get("copyright", ""), str)
+        _copyright = typed(resp.get("copyright") or "", str)
         artists = typed(resp.get("artists", []), list)
         albumartist = ", ".join(a["name"] for a in artists)
         if not albumartist:


### PR DESCRIPTION
Tidal returns null for the copyright field on some tracks. resp.get('copyright', '') only uses the default when the key is absent, not when it's explicitly null, causing an AssertionError in typed(). Fix: use resp.get('copyright') or '' to coerce null to an empty string.