### PR TITLE
fix(deezer): wrap gw.get_track in asyncio.to_thread, cache user ID, add loved tracks support

### DIFF
--- a/streamrip/client/deezer.py
+++ b/streamrip/client/deezer.py
@@ -33,12 +33,14 @@ class DeezerClient(Client):
 
     source = "deezer"
     max_quality = 2
+    _MAX_FAVORITES = 10_000
 
     def __init__(self, config: Config):
         self.global_config = config
         self.client = deezer.Deezer()
         self.logged_in = False
         self.config = config.session.deezer
+        self._logged_in_user_id: int | None = None
 
     async def login(self):
         # Used for track downloads
@@ -51,6 +53,7 @@ class DeezerClient(Client):
         success = self.client.login_via_arl(arl)
         if not success:
             raise AuthenticationError
+        self._logged_in_user_id = self.client.gw.get_user_data()["USER"]["USER_ID"]
         self.logged_in = True
 
     async def get_metadata(self, item_id: str, media_type: str) -> dict:
@@ -98,6 +101,9 @@ class DeezerClient(Client):
         return album_metadata
 
     async def get_playlist(self, item_id: str) -> dict:
+        if item_id.startswith("favorites:"):
+            return await self.get_user_favorites(item_id[len("favorites:"):])
+
         pl_metadata, pl_tracks = await asyncio.gather(
             asyncio.to_thread(self.client.api.get_playlist, item_id),
             asyncio.to_thread(self.client.api.get_playlist_tracks, item_id),
@@ -105,6 +111,23 @@ class DeezerClient(Client):
         pl_metadata["tracks"] = pl_tracks["data"]
         pl_metadata["track_total"] = len(pl_tracks["data"])
         return pl_metadata
+
+    async def get_user_favorites(self, user_id: str) -> dict:
+        # deezer-py's get_user_tracks() drops the limit arg when routing to
+        # get_my_favorite_tracks(), so we detect own profile and call it directly.
+        if int(user_id) == self._logged_in_user_id:
+            tracks = await asyncio.to_thread(
+                self.client.gw.get_my_favorite_tracks, self._MAX_FAVORITES
+            )
+        else:
+            tracks = await asyncio.to_thread(
+                self.client.gw.get_user_tracks, int(user_id), self._MAX_FAVORITES
+            )
+        return {
+            "title": "Loved Tracks",
+            "tracks": tracks,
+            "track_total": len(tracks),
+        }
 
     async def get_artist(self, item_id: str) -> dict:
         artist, albums = await asyncio.gather(
@@ -148,7 +171,7 @@ class DeezerClient(Client):
         # TODO: optimize such that all of the ids are requested at once
         dl_info: dict = {"quality": quality, "id": item_id}
 
-        track_info = self.client.gw.get_track(item_id)
+        track_info = await asyncio.to_thread(self.client.gw.get_track, item_id)
 
         fallback_id = track_info.get("FALLBACK", {}).get("SNG_ID")
 

--- a/streamrip/client/deezer.py
+++ b/streamrip/client/deezer.py
@@ -33,14 +33,14 @@ class DeezerClient(Client):
 
     source = "deezer"
     max_quality = 2
-    _MAX_FAVORITES = 10_000
+    max_favorites = 10_000
 
     def __init__(self, config: Config):
         self.global_config = config
         self.client = deezer.Deezer()
         self.logged_in = False
         self.config = config.session.deezer
-        self._logged_in_user_id: int | None = None
+        self.logged_in_user_id: int | None = None
 
     async def login(self):
         # Used for track downloads
@@ -53,7 +53,7 @@ class DeezerClient(Client):
         success = self.client.login_via_arl(arl)
         if not success:
             raise AuthenticationError
-        self._logged_in_user_id = self.client.gw.get_user_data()["USER"]["USER_ID"]
+        self.logged_in_user_id = self.client.gw.get_user_data()["USER"]["USER_ID"]
         self.logged_in = True
 
     async def get_metadata(self, item_id: str, media_type: str) -> dict:
@@ -115,13 +115,13 @@ class DeezerClient(Client):
     async def get_user_favorites(self, user_id: str) -> dict:
         # deezer-py's get_user_tracks() drops the limit arg when routing to
         # get_my_favorite_tracks(), so we detect own profile and call it directly.
-        if int(user_id) == self._logged_in_user_id:
+        if int(user_id) == self.logged_in_user_id:
             tracks = await asyncio.to_thread(
-                self.client.gw.get_my_favorite_tracks, self._MAX_FAVORITES
+                self.client.gw.get_my_favorite_tracks, self.max_favorites
             )
         else:
             tracks = await asyncio.to_thread(
-                self.client.gw.get_user_tracks, int(user_id), self._MAX_FAVORITES
+                self.client.gw.get_user_tracks, int(user_id), self.max_favorites
             )
         return {
             "title": "Loved Tracks",

--- a/streamrip/rip/parse_url.py
+++ b/streamrip/rip/parse_url.py
@@ -187,6 +187,28 @@ class DeezerDynamicURL(URL):
         raise Exception("Unable to extract Deezer dynamic link.")
 
 
+class DeezerFavoriteURL(URL):
+    favorite_re = re.compile(
+        r"https://(?:www\.)?deezer\.com/[a-z]{2}/profile/(\d+)/loved"
+    )
+
+    @classmethod
+    def from_str(cls, url: str) -> URL | None:
+        match = cls.favorite_re.match(url)
+        if match is None:
+            return None
+        return cls(match, "deezer")
+
+    async def into_pending(
+        self,
+        client: Client,
+        config: Config,
+        db: Database,
+    ) -> Pending:
+        user_id = self.match.group(1)
+        return PendingPlaylist(f"favorites:{user_id}", client, config, db)
+
+
 class SoundcloudURL(URL):
     source = "soundcloud"
 
@@ -228,6 +250,7 @@ def parse_url(url: str) -> URL | None:
     """
     url = url.strip()
     parsed_urls: list[URL | None] = [
+        DeezerFavoriteURL.from_str(url),
         GenericURL.from_str(url),
         QobuzInterpreterURL.from_str(url),
         SoundcloudURL.from_str(url),


### PR DESCRIPTION
## Summary

- **Fix**: `gw.get_track()` was called synchronously inside an async context, blocking the event loop during concurrent downloads. Wrapped in `asyncio.to_thread()` to match all other GW API calls in this file.
- **Perf**: Cache the logged-in user ID as `logged_in_user_id` during `login()` so that `get_user_favorites()` does not make a redundant `get_user_data()` API round-trip on every call.
- **Feat**: Add `DeezerFavoriteURL` to support liked-track profile URLs of the form `https://www.deezer.com/fr/profile/USER_ID/loved`. Routes through `get_playlist()` via a synthetic `favorites:{user_id}` ID and fetches tracks via the GW API (`get_my_favorite_tracks` for own profile, `get_user_tracks` for others).
- **Refactor**: Replace the hardcoded `2000` favorites limit with a class constant `max_favorites = 10_000`.

## Notes

- `deezer-py`'s `get_user_tracks()` silently drops the `limit` argument when the target is the logged-in user (it routes to `get_my_favorite_tracks()` with default `limit=25`). The fix detects own-profile requests using the cached `logged_in_user_id` and calls `get_my_favorite_tracks()` directly with the full limit.

## Test plan

- [x] Download a track/album/playlist to verify `get_downloadable()` still works after the `asyncio.to_thread` fix
- [x] Run `rip url https://www.deezer.com/fr/profile/USER_ID/loved` with own profile → resolves all liked tracks
- [x] Run with another user's public profile → resolves their liked tracks

🤖 Generated with [Claude Code](https://claude.com/claude-code)