### PR TITLE
feat(cli): expose OPUS codec in -c option

### DIFF
--- a/streamrip/rip/cli.py
+++ b/streamrip/rip/cli.py
@@ -65,7 +65,7 @@ def coro(f):
 @click.option(
     "-c",
     "--codec",
-    help="Convert the downloaded files to an audio codec (ALAC, FLAC, MP3, AAC, or OGG)",
+    help="Convert the downloaded files to an audio codec (ALAC, FLAC, MP3, AAC, OGG, or OPUS)",
 )
 @click.option(
     "--no-progress",
@@ -152,7 +152,7 @@ def rip(
 
     if codec is not None:
         c.session.conversion.enabled = True
-        assert codec.upper() in ("ALAC", "FLAC", "OGG", "MP3", "AAC")
+        assert codec.upper() in ("ALAC", "FLAC", "OGG", "MP3", "AAC", "OPUS")
         c.session.conversion.codec = codec.upper()
 
     if no_progress:


### PR DESCRIPTION
## Summary

The `converter.OPUS` class already existed and was fully implemented (using `libopus`, container `.opus`, default bitrate `128k`), and was registered in `converter.get()`. However it was silently excluded from the CLI `-c` / `--codec` option by the validation assert and the help text.

This PR makes OPUS available without adding any new code:

- Add `"OPUS"` to the allowed values in the `assert` in `rip/cli.py`
- Update the `--codec` help string to mention OPUS

## Test plan

- [x] `rip url <deezer_track_url> -c opus` → file downloaded and converted to `.opus`
- [x] `rip --help` shows OPUS in the codec list

🤖 Generated with [Claude Code](https://claude.com/claude-code)