### PR TITLE
fix(converter): fall back to native aac encoder when libfdk_aac unavailable

### DIFF
--- a/streamrip/converter.py
+++ b/streamrip/converter.py
@@ -13,6 +13,18 @@ logger = logging.getLogger("streamrip")
 
 SAMPLING_RATES = {44100, 48000, 88200, 96000, 176400, 192000}
 
+def _check_libfdk_aac() -> bool:
+    try:
+        import subprocess
+        result = subprocess.run(
+            ["ffmpeg", "-encoders"], capture_output=True, text=True, timeout=5
+        )
+        return "libfdk_aac" in result.stdout
+    except Exception:
+        return False
+
+_LIBFDK_AAC_AVAILABLE = _check_libfdk_aac()
+
 
 class Converter:
     """Base class for audio codecs."""
@@ -261,8 +273,9 @@ class OPUS(Converter):
 
 
 class AAC(Converter):
-    """Class for libfdk_aac converter.
+    """Class for AAC converter.
 
+    Uses libfdk_aac if available, falls back to the native FFmpeg aac encoder.
     Default ffmpeg_arg: `-b:a 256k`.
 
     See available options:
@@ -270,7 +283,7 @@ class AAC(Converter):
     """
 
     codec_name = "aac"
-    codec_lib = "libfdk_aac"
+    codec_lib = "libfdk_aac" if _LIBFDK_AAC_AVAILABLE else "aac"
     container = "m4a"
     default_ffmpeg_arg = "-b:a 256k"
 


### PR DESCRIPTION
## Problem

`libfdk_aac` is not included in most standard FFmpeg builds (Ubuntu, Debian, Homebrew without `--with-fdk-aac`…). When a user runs `rip -c aac`, the conversion silently fails because FFmpeg exits with an error when it can't find the encoder — and with `-loglevel panic` the output is suppressed, making the error opaque.

## Fix

Detect `libfdk_aac` availability once at module import time using `ffmpeg -encoders`. If unavailable, fall back to the built-in native `aac` encoder which ships with every standard FFmpeg build.

## Test plan

- [x] System with `libfdk_aac`: `AAC.codec_lib == "libfdk_aac"` (unchanged behaviour)
- [x] System without `libfdk_aac` (most users): `AAC.codec_lib == "aac"`, conversion succeeds
- [x] `rip -c aac url <url>` produces `.m4a` files without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)