### PR TITLE
fix(cli): only show update notice when PyPI version is actually newer

### DIFF
--- a/streamrip/rip/cli.py
+++ b/streamrip/rip/cli.py
@@ -194,7 +194,12 @@ async def url(ctx, urls):
 
             if version_coro is not None:
                 latest_version, notes = await version_coro
-                if latest_version != __version__:
+                def _ver(v):
+                    try:
+                        return tuple(map(int, v.split(".")))
+                    except (ValueError, AttributeError):
+                        return (0, 0, 0)
+                if _ver(latest_version) > _ver(__version__):
                     console.print(
                         f"\n[green]A new version of streamrip [cyan]v{latest_version}[/cyan]"
                         " is available! Run [white][bold]pip3 install streamrip --upgrade[/bold][/white]"


### PR DESCRIPTION
## Problem

The update check compares versions with `!=`:

```python
if latest_version != __version__:
    console.print("A new version is available!")
```

This means the notice also fires when the installed version is *newer* than PyPI — e.g. on a dev install, a pre-release, or a fork. Users on `dev` installs see the "please upgrade" message on every run even though they're already ahead of the release.

## Fix

Compare version tuples numerically so the notice only appears when PyPI actually has a newer release:

```python
def _ver(v):
    try:
        return tuple(map(int, v.split(".")))
    except (ValueError, AttributeError):
        return (0, 0, 0)
if _ver(latest_version) > _ver(__version__):
```

The helper also handles malformed version strings gracefully (returns `(0, 0, 0)`, suppressing the notice).

## Test plan

- [x] Installed version == PyPI version → no notice
- [x] Installed version < PyPI version → notice shown
- [x] Installed version > PyPI version (dev/fork) → no notice
- [ ] Malformed version string from PyPI → no notice, no exception

🤖 Generated with [Claude Code](https://claude.com/claude-code)