### PR TITLE
fix(cli): handle network errors in version check gracefully

### DIFF
--- a/streamrip/rip/cli.py
+++ b/streamrip/rip/cli.py
@@ -457,24 +457,27 @@ async def latest_streamrip_version(verify_ssl: bool = True) -> tuple[str, str | 
     Returns:
         A tuple of (version, release_notes)
     """
-    # Create connector with appropriate SSL settings
-    connector_kwargs = get_aiohttp_connector_kwargs(verify_ssl=verify_ssl)
-    connector = aiohttp.TCPConnector(**connector_kwargs)
+    try:
+        connector_kwargs = get_aiohttp_connector_kwargs(verify_ssl=verify_ssl)
+        connector = aiohttp.TCPConnector(**connector_kwargs)
 
-    async with aiohttp.ClientSession(connector=connector) as s:
-        async with s.get("https://pypi.org/pypi/streamrip/json") as resp:
-            data = await resp.json()
-        version = data["info"]["version"]
+        async with aiohttp.ClientSession(connector=connector) as s:
+            async with s.get("https://pypi.org/pypi/streamrip/json") as resp:
+                data = await resp.json(content_type=None)
+            version = data["info"]["version"]
 
-        if version == __version__:
-            return version, None
+            if version == __version__:
+                return version, None
 
-        async with s.get(
-            "https://api.github.com/repos/nathom/streamrip/releases/latest"
-        ) as resp:
-            json = await resp.json()
-        notes = json["body"]
-    return version, notes
+            async with s.get(
+                "https://api.github.com/repos/nathom/streamrip/releases/latest"
+            ) as resp:
+                gh = await resp.json(content_type=None)
+            notes = gh.get("body") if isinstance(gh, dict) else None
+        return version, notes
+    except Exception as e:
+        logger.debug("Could not check for updates: %s", e)
+        return __version__, None
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Problem

After a successful download, the CLI crashes with a traceback if the GitHub releases API returns a non-JSON response (504 gateway timeout, rate-limit HTML page, etc.):

```
ContentTypeError: 504, message='Attempt to decode JSON with unexpected mimetype:
text/html; charset=utf-8',
url='https://api.github.com/repos/nathom/streamrip/releases/latest'
```

Two root causes:

1. `aiohttp`'s `resp.json()` validates the `Content-Type` header and raises `ContentTypeError` on anything other than `application/json`.
2. The exception propagates uncaught all the way to the top-level CLI handler, crashing the process even though the download itself completed successfully.

## Fix

- Pass `content_type=None` to both `resp.json()` calls to skip MIME type validation — the response is parsed as JSON regardless, and a `JSONDecodeError` is caught by the outer `try/except` below.
- Use `gh.get("body")` instead of `gh["body"]` to handle error responses from the GitHub API (rate-limit, 404, etc.) that don't include a `body` field.
- Wrap the entire function in `try/except Exception` so any network failure (timeout, DNS, SSL, parse error) is logged at `DEBUG` level and the check is silently skipped — the version check should never interrupt or crash a download session.

## Test plan

- [x] Normal run with working network → update notice shown if newer version exists, nothing shown if up to date
- [x] GitHub API returns 504 → no crash, no notice
- [x] GitHub API rate-limited (returns JSON error object without `body`) → no crash, no notice
- [x] No network at all → no crash, no notice

🤖 Generated with [Claude Code](https://claude.com/claude-code)