### PR TITLE
fix: redirect FFmpeg stdin to /dev/null to prevent TTY corruption

### DIFF
--- a/streamrip/client/downloadable.py
+++ b/streamrip/client/downloadable.py
@@ -419,7 +419,7 @@ async def concat_audio_files(paths: list[str], out: str, ext: str, max_files_ope
             "warning",
             outpaths[i],
         )
-        fut = asyncio.create_subprocess_exec(*command, stderr=asyncio.subprocess.PIPE)
+        fut = asyncio.create_subprocess_exec(*command, stdin=asyncio.subprocess.DEVNULL, stderr=asyncio.subprocess.PIPE)
         proc_futures.append(fut)
 
     # Create all processes concurrently

--- a/streamrip/converter.py
+++ b/streamrip/converter.py
@@ -86,6 +86,7 @@ class Converter:
 
         process = await asyncio.create_subprocess_exec(
             *self.command,
+            stdin=asyncio.subprocess.DEVNULL,
             stderr=asyncio.subprocess.PIPE,
         )
         out, err = await process.communicate()


### PR DESCRIPTION
## Problem

After a successful download (with or without conversion), the terminal is left with echo disabled — the user can type but nothing is displayed. Running `reset` or `stty echo` restores it.

This is a classic TTY state corruption: a subprocess altered the terminal's echo/raw mode settings and exited without restoring them.

**Root cause:** both FFmpeg subprocess calls in streamrip are launched without stdin redirection, so FFmpeg inherits the controlling terminal. Even with `-y` (auto-overwrite), FFmpeg probes stdin to detect whether it is interactive and may modify TTY flags (disabling echo, enabling raw mode) for its interactive prompt handling. If the process exits abnormally — or in some cases even normally — those flags are not restored.

Affected calls:
- `converter.py` — audio format conversion
- `client/downloadable.py` — SoundCloud segment concatenation

## Fix

Pass `stdin=asyncio.subprocess.DEVNULL` to both `asyncio.create_subprocess_exec` calls. FFmpeg receives `/dev/null` as its stdin, never touches the terminal, and cannot corrupt TTY state.

## Test plan

- [x] Download a track/album without conversion → terminal echo works after exit
- [x] Download with `-c mp3` / `-c ogg` / `-c aac` conversion → terminal echo works after exit
- [x] Download a SoundCloud track (uses segment concatenation) → terminal echo works after exit
- [x] Verify FFmpeg conversion still produces correct output files

🤖 Generated with [Claude Code](https://claude.com/claude-code)