### PR TITLE
fix(deezer): silence connection pool warnings by sizing the requests adapter correctly

### DIFF
--- a/streamrip/client/deezer.py
+++ b/streamrip/client/deezer.py
@@ -4,6 +4,7 @@ import hashlib
 import logging
 
 import deezer
+import requests
 from Cryptodome.Cipher import AES
 
 from ..config import Config
@@ -39,6 +40,17 @@ class DeezerClient(Client):
         self.client = deezer.Deezer()
         self.logged_in = False
         self.config = config.session.deezer
+
+        # Size the deezer-py requests session pool to match max_connections so
+        # urllib3 never needs to discard connections and logs no warnings.
+        max_conn = config.session.downloads.max_connections
+        adapter = requests.adapters.HTTPAdapter(
+            pool_connections=max_conn,
+            pool_maxsize=max_conn,
+            max_retries=0,
+        )
+        self.client.session.mount("https://", adapter)
+        self.client.session.mount("http://", adapter)
 
     async def login(self):
         # Used for track downloads

--- a/streamrip/client/deezer.py
+++ b/streamrip/client/deezer.py
@@ -41,12 +41,16 @@ class DeezerClient(Client):
         self.logged_in = False
         self.config = config.session.deezer
 
-        # Size the deezer-py requests session pool to match max_connections so
-        # urllib3 never needs to discard connections and logs no warnings.
+        # Increase the deezer-py requests session pool well above max_connections.
+        # Each concurrent download spawns several API calls (metadata, track token,
+        # GW info…) via asyncio.to_thread(), so the actual number of simultaneous
+        # requests easily exceeds max_connections. pool_maxsize is just a ceiling —
+        # no memory is pre-allocated — so a generous value avoids the urllib3
+        # "Connection pool is full" warning without any real cost.
         max_conn = config.session.downloads.max_connections
         adapter = requests.adapters.HTTPAdapter(
             pool_connections=max_conn,
-            pool_maxsize=max_conn,
+            pool_maxsize=max(max_conn * 4, 32),
             max_retries=0,
         )
         self.client.session.mount("https://", adapter)


### PR DESCRIPTION
## Problem

When downloading albums or playlists concurrently, urllib3 logs repeated warnings:

```
WARNING  Connection pool is full, discarding connection: api.deezer.com. Connection pool size: 10
```

The deezer-py library uses a `requests.Session` with the default `HTTPAdapter`, whose `pool_maxsize` is 10. Streamrip calls deezer-py from multiple `asyncio.to_thread()` coroutines running in parallel — one per track being resolved — so the number of simultaneous HTTP connections to `api.deezer.com` easily exceeds the pool ceiling. urllib3 then discards the excess connections and logs a warning for each one.

## Fix

Mount a custom `HTTPAdapter` on the deezer-py session with a `pool_maxsize` large enough to absorb concurrent API calls:

```python
max_conn = config.session.downloads.max_connections
adapter = requests.adapters.HTTPAdapter(
    pool_connections=max_conn,
    pool_maxsize=max(max_conn * 4, 32),
    max_retries=0,
)
self.client.session.mount("https://", adapter)
self.client.session.mount("http://", adapter)
```

`pool_maxsize` is just a ceiling — urllib3 does not pre-allocate connections — so using `max(max_connections × 4, 32)` has no memory cost and ensures the pool is never exhausted under typical usage.

Idea from [hank-bond/streamrip](https://github.com/hank-bond/streamrip).

## Test plan

- [x] Download an album or playlist with `concurrency = true` → no connection pool warnings
- [x] Works with default `max_connections = 10` and with lower values (e.g. 3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)