### PR TITLE
fix(playlist): sanitize playlist names to prevent path traversal via '/'

### DIFF
--- a/streamrip/media/playlist.py
+++ b/streamrip/media/playlist.py
@@ -16,7 +16,7 @@ from ..config import Config
 from ..console import console
 from ..db import Database
 from ..exceptions import NonStreamableError
-from ..filepath_utils import clean_filepath
+from ..filepath_utils import clean_filename, clean_filepath
 from ..metadata import (
     AlbumMetadata,
     Covers,
@@ -171,7 +171,7 @@ class PendingPlaylist(Pending):
             return None
         name = meta.name
         parent = self.config.session.downloads.folder
-        folder = os.path.join(parent, clean_filepath(name))
+        folder = os.path.join(parent, clean_filepath(clean_filename(name)))
         tracks = [
             PendingPlaylistTrack(
                 id,
@@ -243,7 +243,7 @@ class PendingLastfmPlaylist(Pending):
             results: list[tuple[str | None, bool]] = await asyncio.gather(*requests)
 
         parent = self.config.session.downloads.folder
-        folder = os.path.join(parent, clean_filepath(playlist_title))
+        folder = os.path.join(parent, clean_filepath(clean_filename(playlist_title)))
 
         pending_tracks = []
         for pos, (id, from_fallback) in enumerate(results, start=1):


### PR DESCRIPTION
## Summary

- Playlist names containing `/` were passed directly to `clean_filepath()`, which preserves slashes as path separators, causing unintended subdirectory creation and potential path traversal outside the download root.
- Apply `clean_filename()` before `clean_filepath()` in both `PendingPlaylist.resolve()` and `PendingLastfmPlaylist.resolve()` to replace `/` with `-`.

## Root cause

`clean_filename()` replaces `/` with `-` before sanitizing. `clean_filepath()` calls `sanitize_filepath()` which intentionally preserves `/` as a path separator (needed for multi-level folder templates). Playlist folder names are single components and must go through `clean_filename()` first.

Albums were already safe: `AlbumMetadata.format_folder_path()` passes `albumartist` and `title` through `clean_filename()` before template expansion.

## Test plan

- [x] Download a playlist whose name contains `/` (e.g. `Best of 80s/90s`) — confirm it creates a single folder named `Best of 80s-90s` instead of nested `Best of 80s/90s/`
- [x] Download a last.fm playlist — same check
- [x] Existing test suite passes (`pytest`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)