### PR TITLE
fix(qobuz): adapt to album/get and playlist/get no longer returning inline tracks

### DIFF
--- a/streamrip/client/qobuz.py
+++ b/streamrip/client/qobuz.py
@@ -229,8 +229,13 @@ class QobuzClient(Client):
 
         extras = {
             "artist": "albums",
-            "playlist": "tracks",
+            # tracks may come back empty (July 2026 API change); track_ids is
+            # the replacement. Request both so either response shape works.
+            "playlist": "tracks,track_ids",
             "label": "albums",
+            # Qobuz's album/get stopped inlining "tracks" (July 2026); request
+            # the id list instead. Consumed by get_album_track_ids().
+            "album": "track_ids",
         }
 
         if media_type in extras:

--- a/streamrip/metadata/playlist.py
+++ b/streamrip/metadata/playlist.py
@@ -3,7 +3,7 @@ from dataclasses import dataclass
 
 from .album import AlbumMetadata
 from .track import TrackMetadata
-from .util import typed
+from .util import safe_get, typed
 
 NON_STREAMABLE = "_non_streamable"
 ORIGINAL_DOWNLOAD = "_original_download"
@@ -51,7 +51,7 @@ class PlaylistMetadata:
         name = typed(resp["name"], str)
         tracks = []
 
-        for i, track in enumerate(resp["tracks"]["items"]):
+        for i, track in enumerate(safe_get(resp, "tracks", "items", default=[])):
             meta = TrackMetadata.from_qobuz(
                 AlbumMetadata.from_qobuz(track["album"]),
                 track,
@@ -60,6 +60,12 @@ class PlaylistMetadata:
                 logger.error(f"Track {i+1} in playlist {name} not available for stream")
                 continue
             tracks.append(meta)
+
+        if not tracks and resp.get("track_ids"):
+            # Qobuz's playlist/get returns an empty "tracks" object since July
+            # 2026; fall back to the id list from the track_ids extra. Each
+            # track's metadata is fetched by PendingPlaylistTrack.resolve().
+            return cls(name, [str(id) for id in resp["track_ids"]])
 
         return cls(name, tracks)
 

--- a/streamrip/metadata/util.py
+++ b/streamrip/metadata/util.py
@@ -3,6 +3,10 @@ from typing import Optional, Type, TypeVar
 
 
 def get_album_track_ids(source: str, resp) -> list[str]:
+    if source == "qobuz" and "tracks" not in resp:
+        # Qobuz's album/get stopped inlining "tracks" (July 2026); the client
+        # requests extra=track_ids instead.
+        return resp["track_ids"]
     tracklist = resp["tracks"]
     if source == "qobuz":
         tracklist = tracklist["items"]


### PR DESCRIPTION

Fixes #1012.

**Problem**

On ~2026-07-18 Qobuz removed inline track listings from its metadata API: `album/get` no longer returns a `tracks` object at all (and rejects `extra=tracks` with HTTP 400), and `playlist/get?extra=tracks` returns an always-empty `tracks.items`. As a result every Qobuz album download crashes with `KeyError: 'tracks'` and every playlist download silently resolves 0 tracks. The replacement contract, confirmed against the current web player (bundle 8.2.0-b034), is `extra=track_ids`, which returns the plain id list.

**Changes**

- `client/qobuz.py`: request `extra=track_ids` for albums, and `extra=tracks,track_ids` for playlists (both values, so either the old or new server behavior works).
- `metadata/util.py`: `get_album_track_ids()` reads `resp["track_ids"]` when the legacy `tracks` object is absent.
- `metadata/playlist.py`: `PlaylistMetadata.from_qobuz()` tolerates a missing/empty `tracks` object and falls back to the `track_ids` list — the same `list[str]` shape the Deezer path already uses; ids are hydrated per-track by `PendingPlaylistTrack.resolve()` exactly as before.

No new requests are introduced: albums and playlists already fetched each track individually via `track/get` (which is unchanged); these endpoints only ever needed the id lists.

**Compatibility**

- Legacy response shapes still take priority when present, so nothing changes if Qobuz reverts or rolls out regionally.
- No behavior change for other sources; no new dependencies.
- Untested edge: playlists longer than the old `limit=500` paging window — `track_ids` returned complete lists for everything tested (up to 100 tracks), but very large playlists are worth a look.

**Testing (live API, Qobuz Studio subscription, US store)**

- A/B repro: pristine `dev` crashes `KeyError: 'tracks'` on any album; with this patch the same call returns the full id list.
- Real download: a 10-track hi-res album (24/192) downloaded 10/10 tracks with correct tags.
- Playlist: a 66-track editorial playlist resolves 66 pending tracks (0 before the patch).
- Spot-checked artist (`extra=albums`, 353 albums returned) and single-track flows: unaffected.

Happy to add fixture tests for the new response shape if wanted.


🤖 Generated with [Claude Code](https://claude.com/claude-code)
