### PR TITLE
Fix failed downloads being marked as downloaded, add rip repair

### DIFF
--- a/streamrip/exceptions.py
+++ b/streamrip/exceptions.py
@@ -68,3 +68,11 @@ class NonStreamableError(Exception):
 
 class ConversionError(Exception):
     """ConversionError."""
+
+
+class TrackDownloadFailedError(Exception):
+    """Raised when a track fails to download after retrying.
+
+    Signals to Media.rip() that postprocess (tagging, marking downloaded)
+    must not run for this track.
+    """

--- a/streamrip/media/track.py
+++ b/streamrip/media/track.py
@@ -139,16 +139,22 @@ class PendingTrack(Pending):
             return None
 
         source = self.client.source
+        # Every failure below has to be recorded, not just logged. An unlogged
+        # failure leaves no trace anywhere: no file, no downloads.db row, and
+        # nothing in the failed db for `rip repair` to retry -- the track just
+        # silently goes missing from the album.
         try:
             resp = await self.client.get_metadata(self.id, "track")
         except NonStreamableError as e:
             logger.error(f"Track {self.id} not available for stream on {source}: {e}")
+            self.db.set_failed(source, "track", self.id)
             return None
 
         try:
             meta = TrackMetadata.from_resp(self.album, source, resp)
         except Exception as e:
             logger.error(f"Error building track metadata for {self.id}: {e}")
+            self.db.set_failed(source, "track", self.id)
             return None
 
         if meta is None:
@@ -163,6 +169,7 @@ class PendingTrack(Pending):
             logger.error(
                 f"Error getting downloadable data for track {meta.tracknumber} [{self.id}]: {e}"
             )
+            self.db.set_failed(source, "track", self.id)
             return None
 
         downloads_config = self.config.session.downloads
@@ -201,16 +208,20 @@ class PendingSingle(Pending):
             )
             return None
 
+        # As in PendingTrack.resolve: record every failure, so a track that
+        # dies here is retryable by `rip repair` instead of vanishing.
         try:
             resp = await self.client.get_metadata(self.id, "track")
         except NonStreamableError as e:
             logger.error(f"Error fetching track {self.id}: {e}")
+            self.db.set_failed(self.client.source, "track", self.id)
             return None
         # Patch for soundcloud
         try:
             album = AlbumMetadata.from_track_resp(resp, self.client.source)
         except Exception as e:
             logger.error(f"Error building album metadata for track {id=}: {e}")
+            self.db.set_failed(self.client.source, "track", self.id)
             return None
 
         if album is None:
@@ -224,6 +235,7 @@ class PendingSingle(Pending):
             meta = TrackMetadata.from_resp(album, self.client.source, resp)
         except Exception as e:
             logger.error(f"Error building track metadata for track {id=}: {e}")
+            self.db.set_failed(self.client.source, "track", self.id)
             return None
 
         if meta is None:

--- a/streamrip/media/track.py
+++ b/streamrip/media/track.py
@@ -7,7 +7,7 @@ from .. import converter
 from ..client import Client, Downloadable
 from ..config import Config
 from ..db import Database
-from ..exceptions import NonStreamableError
+from ..exceptions import NonStreamableError, TrackDownloadFailedError
 from ..filepath_utils import clean_filename
 from ..metadata import AlbumMetadata, Covers, TrackMetadata, tag_file
 from ..progress import add_title, get_progress_callback, remove_title
@@ -71,6 +71,16 @@ class Track(Media):
                     self.db.set_failed(
                         self.downloadable.source, "track", self.meta.info.id
                     )
+                    if os.path.isfile(self.download_path):
+                        os.remove(self.download_path)
+                    # postprocess() normally does this, but raising below
+                    # skips it, which would leave a phantom title in the
+                    # progress display for the rest of the run.
+                    if self.is_single:
+                        remove_title(self.meta.title)
+                    raise TrackDownloadFailedError(
+                        f"{self.meta.title} ({self.meta.info.id})"
+                    ) from e
 
     async def postprocess(self):
         if self.is_single:

--- a/streamrip/rip/cli.py
+++ b/streamrip/rip/cli.py
@@ -362,6 +362,87 @@ def database_browse(ctx, table):
 
 
 @rip.command()
+@click.option("-y", "--yes", help="Don't ask for confirmation.", is_flag=True)
+@click.option(
+    "--flat",
+    help="Put repaired tracks straight in the download folder instead of "
+    "their album folder.",
+    is_flag=True,
+)
+@click.pass_context
+@coro
+async def repair(ctx, yes, flat):
+    """Retry downloads that previously failed.
+
+    Reads the failed downloads database, retries each item, and clears it
+    from the failed database on success. Items that fail again stay logged
+    so they can be retried later.
+
+    Failed tracks are retried individually, but are placed in their album's
+    folder so they rejoin the album they were originally missing from. Pass
+    --flat to put them in the download folder instead.
+    """
+    if ctx.obj["config"] is None:
+        return
+
+    with ctx.obj["config"] as cfg:
+        cfg: Config
+        # A repaired track is nearly always a track missing from an album that
+        # was otherwise downloaded, so it needs to land in that album's folder
+        # rather than loose in the download root. This only touches the
+        # in-memory session copy, so config.toml is left alone.
+        if not flat:
+            cfg.session.filepaths.add_singles_to_folder = True
+        failed_db = db.Failed(cfg.session.database.failed_downloads_path)
+        downloads_db = db.Downloads(cfg.session.database.downloads_path)
+        failed_items = failed_db.all()
+
+        if not failed_items:
+            console.print("[green]No failed downloads to repair!")
+            return
+
+        console.print(
+            f"Found [yellow]{len(failed_items)}[/yellow] failed download(s)."
+        )
+        if not yes and not Confirm.ask("Retry them now?"):
+            console.print("[green]Repair aborted")
+            return
+
+        # A failed item should never also be logged as downloaded, but older
+        # versions of streamrip could mark one downloaded even after it
+        # failed. Clear that stale state so the retry below isn't skipped.
+        for _source, _media_type, item_id in failed_items:
+            downloads_db.remove(id=item_id)
+
+        async with Main(cfg) as main:
+            await main.add_all_by_id(failed_items)
+            await main.resolve()
+            await main.rip()
+
+        # Nothing in the download pipeline removes rows from the failed db, so
+        # success can't be detected by diffing it. Instead rely on the
+        # invariant this patch establishes: set_downloaded() is only reached
+        # via postprocess(), which a failed download never gets to. So an item
+        # present in the downloads db now is one that just succeeded.
+        repaired = [
+            item_id
+            for _, _, item_id in failed_items
+            if downloads_db.contains(id=item_id)
+        ]
+        for item_id in repaired:
+            failed_db.remove(id=item_id)
+
+        console.print(
+            f"[green]Repaired {len(repaired)}/{len(failed_items)} item(s).[/green]"
+        )
+        if len(repaired) < len(failed_items):
+            console.print(
+                f"[yellow]{len(failed_items) - len(repaired)} item(s) failed again "
+                "and are still logged. Run [bold]rip repair[/bold] to try again."
+            )
+
+
+@rip.command()
 @click.option(
     "-f",
     "--first",

--- a/streamrip/rip/cli.py
+++ b/streamrip/rip/cli.py
@@ -361,6 +361,38 @@ def database_browse(ctx, table):
         )
 
 
+async def _albums_for(main, failed_items):
+    """Map failed tracks onto the albums that contain them.
+
+    Returns (album targets, items to retry as they are). Anything whose album
+    cannot be determined is passed through untouched rather than dropped.
+    """
+    targets: list[tuple[str, str, str]] = []
+    unresolved: list[tuple[str, str, str]] = []
+    seen: set[tuple[str, str]] = set()
+
+    for source, media_type, item_id in failed_items:
+        if media_type != "track":
+            targets.append((source, media_type, item_id))
+            continue
+        try:
+            client = await main.get_logged_in_client(source)
+            resp = await client.get_metadata(item_id, "track")
+            album_id = str((resp.get("album") or {}).get("id") or "")
+        except Exception as e:
+            logger.debug("Could not find the album for %s: %s", item_id, e)
+            album_id = ""
+
+        if not album_id:
+            unresolved.append((source, media_type, item_id))
+            continue
+        if (source, album_id) not in seen:
+            seen.add((source, album_id))
+            targets.append((source, "album", album_id))
+
+    return targets, unresolved
+
+
 @rip.command()
 @click.option("-y", "--yes", help="Don't ask for confirmation.", is_flag=True)
 @click.option(
@@ -415,7 +447,25 @@ async def repair(ctx, yes, flat):
             downloads_db.remove(id=item_id)
 
         async with Main(cfg) as main:
-            await main.add_all_by_id(failed_items)
+            # Retry through the album rather than track by track. Resolving a
+            # single track builds its album metadata from the track response,
+            # which on Tidal carries only an id, title and cover -- no track
+            # count, and the track's artists in place of the album artist. The
+            # folder that produces differs from the album's own in both, so
+            # repaired tracks land in a separate folder instead of rejoining
+            # the album.
+            #
+            # Going through the album gets the real metadata, the right
+            # folder, disc subfolders and cover art, and costs nothing extra:
+            # tracks already in the downloads db are skipped, so only what is
+            # missing gets fetched.
+            targets, unresolved = await _albums_for(main, failed_items)
+            if unresolved:
+                console.print(
+                    f"[yellow]{len(unresolved)} item(s) had no album to retry "
+                    "through; fetching them individually."
+                )
+            await main.add_all_by_id(targets + unresolved)
             await main.resolve()
             await main.rip()
 


### PR DESCRIPTION
## The problem

When a track fails to download twice, it gets logged to the failed-downloads database — and then marked as **successfully downloaded**.

`Track.download()` retried once and, on a second failure, called `db.set_failed(...)` but then returned normally. `Media.rip()` runs `preprocess → download → postprocess` unconditionally, so `postprocess()` went on to call `db.set_downloaded(...)`. From that point on, `PendingTrack.resolve()` / `PendingSingle.resolve()` see the track in the downloads database and skip it, permanently. Re-running the same URL doesn't help, and it survives restarts. The only recovery is to find the missing tracks by hand.

I hit this on a real library. Of 629 rows in `downloads.db`, 18 were also present in `failed_downloads.db` — every single failed track had been recorded as downloaded.

The failures also leave truncated files behind. Because downloads always restart from byte 0 (`BasicDownloadable` opens the path `"wb"` and sends no `Range` header), a partial is never resumed — it just stays in the library as a file with correct tags and a plausible size that fails to decode partway through. I found 8 of these, silently unplayable past the truncation point.

There's a second, quieter version of the same bug: `PendingTrack.resolve()` has four failure paths and only one of them recorded anything. If the metadata request failed, if building metadata raised, or if fetching the downloadable URL failed, it logged a line and returned `None` — no file, no downloads row, nothing in the failed database. The track just went missing from the album with no trace anywhere. `PendingSingle.resolve()` had the same gap on three paths.

Finally, `config.toml` has always said "*Then, `rip repair` can be called to retry the downloads*", but no such command existed. The failed-downloads database was write-only — nothing ever read it back.

## What this changes

**`Don't mark failed downloads as downloaded`** — raise `TrackDownloadFailedError` on persistent failure so `Media.rip()` stops before `postprocess()` and `set_downloaded()` is never reached for a track that failed. Also delete the partial file, since it can never be resumed. `Album.download()` and `Playlist.download()` already wrap each `track.rip()` in its own try/except and continue, so raising cannot abort a whole album or playlist.

**`Record tracks that fail while resolving`** — call `set_failed()` on the resolve paths that previously returned `None` silently, so those failures are retryable instead of invisible.

**`Add rip repair to retry failed downloads`** — implements the command `config.toml` already documents. It reads the failed database, retries each item through the normal pipeline, and clears the ones that succeed.

Two details worth flagging for review:

- Success is determined by membership in the *downloads* database, not by diffing the failed database before/after. Nothing in the pipeline removes rows from the failed database, so a before/after diff always reports zero repaired. Checking the downloads database is sound precisely because of the first commit: `set_downloaded()` is now only reachable from `postprocess()`, which a failed track never gets to.
- Repaired items are placed in their album's folder, because a failed item is usually one track missing from an otherwise complete album, and retrying resolves it as a single. `--flat` restores the old root-folder behaviour.


> **Interaction with #1009:** that PR adds proper `Range`-based resumable downloads. If it lands, deleting the partial file here becomes actively wrong — it would throw away exactly the bytes #1009 wants to resume from. The deletion is only correct while downloads restart from byte 0, which is true on `dev` today. Happy to make the deletion conditional, drop it, or rebase on #1009, whichever the maintainers prefer. The rest of this PR is independent of that question.


### Retrying through the album

Repair originally re-added each failed track by id, which resolves as a single. That builds album metadata from the *track* response — and on Tidal a track response carries almost nothing about its album:

```
album object keys: ['cover', 'id', 'title', 'vibrantColor', 'videoCover']
```

No track count, so `tracktotal` falls back to 1, and the artist is the track's artists rather than the album artist. Where `folder_format` uses `{albumartist}` or `{tracktotal}`, repaired tracks therefore land somewhere other than the album they belong to:

```
Simon Carter/Beautiful Destruction (2021) [MP4] ... [11 tracks]      the album
Simon Carter, Fabsi/Beautiful Destruction (2021) [FLAC] ... [1 tracks]
```

Running it against a real library produced 18 such folders holding 107 files.

It now looks up each failed track's album and retries through that. The metadata is then the album's own, so the folder, disc subfolders and cover art are all correct, and nothing extra is downloaded — tracks already in the downloads database are skipped, so only the missing ones are fetched. Albums are de-duplicated, so several failures from one album cost one retry rather than several. Anything whose album cannot be determined is still retried on its own.

## Testing

- Drove a real `Track.rip()` against a downloadable that writes a partial file then raises, with temporary databases: confirmed it raises, logs to the failed database, does **not** mark downloaded, removes the partial, and leaves no stale progress-bar title.
- Ran `rip repair` against a real Qobuz account and recovered all 18 stuck tracks. Roughly half the large files hit genuine `IncompleteRead` errors along the way, which made a good test: on every pass the downloaded and failed databases stayed disjoint. Under the old code those would have become permanently lost tracks.
- Every commit compiles standalone.

Happy to split this further or adjust anything.


