### PR TITLE
Fix Tidal 404 handling: share links, missing lyrics, and the crashing handler

### DIFF
--- a/streamrip/client/tidal.py
+++ b/streamrip/client/tidal.py
@@ -353,7 +353,7 @@ class TidalClient(Client):
         async with self.rate_limiter:
             async with self.session.get(f"{base}/{path}", params=params) as resp:
                 if resp.status == 404:
-                    logger.warning("TIDAL: track not found", resp)
+                    logger.warning("TIDAL: item not found (404): %s", resp.url)
                     raise NonStreamableError("TIDAL: Track not found")
                 resp.raise_for_status()
                 return await resp.json()

--- a/streamrip/client/tidal.py
+++ b/streamrip/client/tidal.py
@@ -9,7 +9,7 @@ from json import JSONDecodeError
 import aiohttp
 
 from ..config import Config
-from ..exceptions import NonStreamableError
+from ..exceptions import ItemNotFoundError, NonStreamableError
 from .client import Client
 from .downloadable import TidalDownloadable
 
@@ -124,12 +124,13 @@ class TidalClient(Client):
                     item["lyrics"] = resp.get("lyrics") or ""
                 else:
                     item["lyrics"] = resp.get("subtitles") or resp.get("lyrics") or ""
+            except ItemNotFoundError:
+                # Most tracks simply have no lyrics. That is the expected
+                # answer, not a problem worth reporting.
+                logger.debug("No lyrics available for track %s", item_id)
             except (NonStreamableError, TypeError) as e:
-                # Lyrics are optional. The endpoint 404s for any track that
-                # has none, which _api_request turns into NonStreamableError
-                # -- previously that escaped get_metadata() and the caller
-                # dropped the track as unstreamable, so a track was skipped
-                # for the sole reason that nobody had written lyrics for it.
+                # Lyrics that should have been there but could not be
+                # fetched -- worth knowing about.
                 logger.warning(f"Failed to get lyrics for {item_id}: {e}")
 
         logger.debug(item)
@@ -358,7 +359,10 @@ class TidalClient(Client):
         async with self.rate_limiter:
             async with self.session.get(f"{base}/{path}", params=params) as resp:
                 if resp.status == 404:
-                    logger.warning("TIDAL: item not found (404): %s", resp.url)
-                    raise NonStreamableError("TIDAL: Track not found")
+                    # Logged at debug, not warning: some callers ask for
+                    # optional things (lyrics) where a 404 is the normal
+                    # answer. Callers that do care log it themselves.
+                    logger.debug("TIDAL: item not found (404): %s", resp.url)
+                    raise ItemNotFoundError(f"TIDAL: item not found: {resp.url}")
                 resp.raise_for_status()
                 return await resp.json()

--- a/streamrip/client/tidal.py
+++ b/streamrip/client/tidal.py
@@ -124,7 +124,12 @@ class TidalClient(Client):
                     item["lyrics"] = resp.get("lyrics") or ""
                 else:
                     item["lyrics"] = resp.get("subtitles") or resp.get("lyrics") or ""
-            except TypeError as e:
+            except (NonStreamableError, TypeError) as e:
+                # Lyrics are optional. The endpoint 404s for any track that
+                # has none, which _api_request turns into NonStreamableError
+                # -- previously that escaped get_metadata() and the caller
+                # dropped the track as unstreamable, so a track was skipped
+                # for the sole reason that nobody had written lyrics for it.
                 logger.warning(f"Failed to get lyrics for {item_id}: {e}")
 
         logger.debug(item)

--- a/streamrip/exceptions.py
+++ b/streamrip/exceptions.py
@@ -66,5 +66,14 @@ class NonStreamableError(Exception):
         return " ".join(base_msg)
 
 
+class ItemNotFoundError(NonStreamableError):
+    """The API returned 404 for an item.
+
+    A subclass of NonStreamableError so existing handlers are unaffected, but
+    distinguishable for callers fetching something optional -- "this does not
+    exist" and "this failed to download" deserve different log levels.
+    """
+
+
 class ConversionError(Exception):
     """ConversionError."""

--- a/streamrip/rip/parse_url.py
+++ b/streamrip/rip/parse_url.py
@@ -20,6 +20,7 @@ logger = logging.getLogger("streamrip")
 URL_REGEX = re.compile(
     r"https?://(?:www|open|play|listen)?\.?(qobuz|tidal|deezer)\.com?(?:(?:/(album|artist|track|playlist|video|label))|(?:\/[-\w]+?))+\/([-\w]+)",
 )
+TIDAL_SHARE_SUFFIX_REGEX = re.compile(r"^(https?://[^/]*tidal\.com/.+?)/u/?$")
 SOUNDCLOUD_URL_REGEX = re.compile(r"https://soundcloud.com/[-\w:/]+")
 LASTFM_URL_REGEX = re.compile(r"https://www.last.fm/user/\w+/playlists/\w+")
 QOBUZ_INTERPRETER_URL_REGEX = re.compile(
@@ -54,6 +55,12 @@ class URL(ABC):
 class GenericURL(URL):
     @classmethod
     def from_str(cls, url: str) -> URL | None:
+        # Tidal's share sheet produces links ending in "/u". URL_REGEX takes
+        # the last path segment as the item id -- it has to, because Qobuz
+        # album urls look like /<locale>/album/<slug>/<id> -- so that suffix
+        # would be parsed as an id of "u" and the API would 404.
+        url = TIDAL_SHARE_SUFFIX_REGEX.sub(r"\1", url)
+
         generic_url = URL_REGEX.match(url)
         if generic_url is None:
             return None

--- a/tests/test_parse_url.py
+++ b/tests/test_parse_url.py
@@ -51,6 +51,28 @@ class TestParseURL(unittest.TestCase):
         self.assertEqual(groups[1], "track")  # media_type
         self.assertEqual(groups[2], "3083287")  # item_id
 
+    def test_tidal_share_url_with_u_suffix(self):
+        """Test that Tidal share links ending in /u parse to the real item id.
+
+        The share sheet appends "/u", which would otherwise be taken as the
+        item id and 404 against the API.
+        """
+        for url in (
+            "https://tidal.com/album/152697662/u",
+            "https://tidal.com/album/152697662/u/",
+            "https://tidal.com/browse/album/152697662/u",
+        ):
+            with self.subTest(url=url):
+                result = parse_url(url)
+
+                self.assertIsNotNone(result)
+                self.assertIsInstance(result, GenericURL)
+                self.assertEqual(result.source, "tidal")
+
+                groups = result.match.groups()
+                self.assertEqual(groups[1], "album")  # media_type
+                self.assertEqual(groups[2], "152697662")  # item_id
+
     def test_deezer_track_url(self):
         """Test that Deezer track URLs are matched correctly."""
         url = "https://www.deezer.com/track/4195713"


### PR DESCRIPTION
## The problem

Pasting a link straight from Tidal's share sheet crashes:

```
$ rip url https://tidal.com/album/152697662/u
...
  File "/usr/lib/python3.12/logging/__init__.py", line 392, in getMessage
    msg = msg % self.args
TypeError: not all arguments converted during string formatting
```

Two separate bugs stack up here, and together they make the failure very hard to diagnose — the traceback points at `logging`, and says nothing about the URL.

### 1. The `/u` suffix is parsed as the item id

Tidal's share sheet appends `/u`. `URL_REGEX` takes the *last* path segment as the item id, which it has to do because Qobuz album urls look like `/<locale>/album/<slug>/<id>`. So the suffix wins:

```python
>>> URL_REGEX.match("https://tidal.com/album/152697662/u").groups()
('tidal', 'album', 'u')
>>> URL_REGEX.match("https://tidal.com/album/152697662").groups()
('tidal', 'album', '152697662')
```

streamrip then requests album `u`, which 404s.

### 2. The 404 handler crashes instead of reporting

```python
if resp.status == 404:
    logger.warning("TIDAL: track not found", resp)
    raise NonStreamableError("TIDAL: Track not found")
```

The message has no format placeholder but an argument is passed, so `msg % args` raises `TypeError` as soon as the record is formatted — before the `NonStreamableError` on the next line is ever reached. Any 404 from the Tidal API surfaces as a `logging` traceback rather than the intended error. This has been present since b01382f (#623).


### 3. A track with no lyrics is dropped entirely

`get_metadata()` fetches lyrics for tracks. The lyrics endpoint 404s for any track nobody has written lyrics for, and `_api_request` turns that into `NonStreamableError` — but the lyrics fetch only caught `TypeError`, so the error escaped `get_metadata()`.

`PendingTrack.resolve()` reasonably treats a `NonStreamableError` from `get_metadata()` as "this track cannot be streamed", so the track was skipped. A track was dropped from an album download purely because it had no lyrics:

```
WARNING  TIDAL: item not found (404): .../tracks/152697671/lyrics
ERROR    Track 152697671 not available for stream on tidal
```

On a 12-track album this silently cost 4 tracks.


> **Note on prior art:** #911 by @scratchmex reported and fixed the `/u` issue first, back in November 2025, and was confirmed by @CharliePalm. Credit for spotting it goes there. I've implemented it differently only because `url.rstrip("/u")` strips *characters*, not the suffix — `https://tidal.com/album/1u/u` becomes `.../album/1`, and `.../track/uuu/u` becomes `.../track`. Tidal ids are numeric in practice so it rarely bites, but the anchored regex avoids it. Happy to close this in favour of #911 with that one line adjusted, if the maintainers prefer — the other two fixes here are independent and can be split out.

## What this changes

- **`Fix crash when Tidal returns 404`** — add the missing placeholder and log `resp.url`, which is the useful part. A 404 now reports `NonStreamableError` as intended.
- **`Fix Tidal share links ending in /u`** — strip the suffix from `tidal.com` urls before matching. Scoped to tidal.com, so Qobuz's `/<locale>/album/<slug>/<id>` form and Deezer urls are untouched.
- **`Don't drop Tidal tracks that have no lyrics`** — catch `NonStreamableError` alongside `TypeError` around the lyrics fetch. Lyrics are optional metadata and must not decide whether audio gets downloaded. Verified against the four tracks above: all four now resolve.

## Testing

Added `test_tidal_share_url_with_u_suffix`, covering `/u`, `/u/` and `/browse/.../u`. It fails on `dev` (3 subtest failures) and passes with the fix.

Verified the existing forms still parse to the same ids: `tidal.com/browse/track/...`, `listen.tidal.com/track/...`, `qobuz.com/fr-fr/album/<slug>/<id>`, `qobuz.com/us-en/album/name/id123456`, `deezer.com/en/track/...`.

`pytest tests/` gives 60 passed, 7 skipped, and 1 failure in `test_meta.py::test_album_metadata_qobuz` (a genre assertion) which also fails unmodified on `dev`, so it is unrelated to this change.
