### PR TITLE
Stop cleanly on Ctrl-C, and ask which albums to take from an artist

### DIFF
--- a/streamrip/config.py
+++ b/streamrip/config.py
@@ -222,6 +222,12 @@ class CliConfig:
     progress_bars: bool
     # The maximum number of search results to show in the interactive menu
     max_search_results: int
+    # How to order the album list shown for an artist url.
+    # "type": albums first, then EPs, then singles, each oldest first.
+    #         Sources that do not report a release type fall back to "date".
+    # "date": one chronological list.
+    # Defaulted so configs written before this existed still load.
+    artist_album_sort: str = "type"
 
 
 @dataclass(slots=True)

--- a/streamrip/config.toml
+++ b/streamrip/config.toml
@@ -190,6 +190,13 @@ text_output = true
 progress_bars = true
 # The maximum number of search results to show in the interactive menu
 max_search_results = 100
+# Order of the album list shown for an artist url.
+#   "type"  albums first, then EPs, then singles; each oldest first
+#   "date"  one chronological list, oldest first
+# Sources that do not report a release type (Qobuz) behave the same either
+# way. Ties break on title, then quality, then id, so the order does not
+# change between runs. Override for one run with `rip url --sort date`.
+artist_album_sort = "type"
 
 [misc]
 # Metadata to identify this config file. Do not change.

--- a/streamrip/media/artist.py
+++ b/streamrip/media/artist.py
@@ -1,14 +1,19 @@
 import asyncio
+import dataclasses
 import logging
 import re
+import sys
 from dataclasses import dataclass
+from typing import ClassVar
 
 from ..client import Client
 from ..config import Config, QobuzDiscographyFilterConfig
 from ..console import console
+from ..utils import menu
 from ..db import Database
 from ..exceptions import NonStreamableError
-from ..metadata import ArtistMetadata
+from ..metadata.artist import ArtistMetadata
+from ..metadata.search_results import AlbumSummary
 from .album import Album, PendingAlbum
 from .media import Media, Pending
 
@@ -28,11 +33,20 @@ class Artist(Media):
     albums: list[PendingAlbum]
     client: Client
     config: Config
+    summaries: list[AlbumSummary] = dataclasses.field(default_factory=list)
+
+    # Set to False by `rip url --no-confirm` for unattended runs.
+    confirm_selection: ClassVar[bool] = True
+    # "type" groups albums, then EPs, then singles, each oldest first.
+    # "date" is a single chronological run. Set by `rip url --sort`.
+    sort_by: ClassVar[str] = "type"
 
     async def preprocess(self):
         pass
 
     async def download(self):
+        if not self._select_albums():
+            return
         filter_conf = self.config.session.qobuz_filters
         if filter_conf.repeats:
             console.log(
@@ -41,6 +55,87 @@ class Artist(Media):
             await self._resolve_then_download(filter_conf)
         else:
             await self._download_async(filter_conf)
+
+    def _select_albums(self) -> bool:
+        """Let the user pick from the discography before anything downloads.
+
+        Artist search is unreliable on both Qobuz and Tidal, so an artist url
+        can easily be the wrong person entirely, and even the right one brings
+        a lot nobody asked for. Uses the same menu as `rip search`, so it looks
+        and behaves the same way. Returns False if nothing was chosen.
+        """
+        if not (
+            self.confirm_selection
+            and self.summaries
+            and len(self.albums) > 1
+            and sys.stdin.isatty()
+        ):
+            return True
+
+        # Sources return the discography in their own order, which is not
+        # useful for picking through 80-odd releases.
+        sort_by = self.sort_by
+        if sort_by not in ("type", "date"):
+            # A missing key is covered by the dataclass default; this is a
+            # value that is present but not one we understand. Say so rather
+            # than silently picking an order the user did not ask for.
+            logger.warning(
+                "Unknown cli.artist_album_sort %r, using 'type'. "
+                "Valid values are 'type' and 'date'.",
+                sort_by,
+            )
+            sort_by = "type"
+
+        # Unknown type ranks with albums, so a source that does not report one
+        # (Qobuz) just sorts chronologically rather than pretending.
+        rank = {"album": 0, "": 0, "ep": 1, "single": 2}
+
+        def sort_key(i: int):
+            s = self.summaries[i]
+            date = s.date_released or ""
+            # Dates arrive as ISO strings, which sort correctly as text, but
+            # can also be a bare year or the literal "Unknown". Anything
+            # unparseable goes last rather than landing in the middle.
+            date_key = date if date[:4].isdigit() else "9999"
+            # Title and quality break ties, so two editions of the same
+            # release always sit together. The id is a last resort that never
+            # ties, because sources do list the same release twice with every
+            # visible field identical -- without it those two could swap
+            # places between runs.
+            tail = (date_key, s.name.lower(), s.quality, str(s.id))
+            return (rank.get(s.release_type, 0), *tail) if sort_by == "type" else tail
+
+        order = sorted(range(len(self.summaries)), key=sort_key)
+
+        # The artist is the same on every row here, so show what actually
+        # distinguishes releases: year, size, quality and kind.
+        entries = []
+        for n, i in enumerate(order, 1):
+            s = self.summaries[i]
+            year = (s.date_released or "")[:4] or "----"
+            quality = f"  {s.quality}" if s.quality else ""
+            kind = f"  ({s.release_type})" if s.release_type in ("ep", "single") else ""
+            entries.append(
+                f"{n}. {year}  {s.name[:48]}{kind}  [{s.num_tracks} trk]{quality}"
+            )
+
+        chosen = menu.multi_select(
+            entries,
+            title=(
+                f"{self.name} - {len(self.summaries)} releases\n"
+                "SPACE - select, ENTER - download, ESC - exit"
+            ),
+            previews=[self.summaries[i].preview() for i in order],
+        )
+
+        if not chosen:
+            menu.announce_nothing_chosen()
+            return False
+
+        keep = {self.summaries[order[i]].id for i in chosen}
+        self.albums = [a for a in self.albums if str(a.id) in keep]
+        console.print(f"[green]Downloading {len(self.albums)} release(s).\n")
+        return True
 
     async def postprocess(self):
         pass
@@ -205,4 +300,4 @@ class PendingArtist(Pending):
             PendingAlbum(album_id, self.client, self.config, self.db)
             for album_id in meta.album_ids()
         ]
-        return Artist(meta.name, albums, self.client, self.config)
+        return Artist(meta.name, albums, self.client, self.config, meta.albums)

--- a/streamrip/metadata/artist.py
+++ b/streamrip/metadata/artist.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 import logging
-from dataclasses import dataclass
+from dataclasses import dataclass, field
+
+from .search_results import AlbumSummary
 
 logger = logging.getLogger("streamrip")
 
@@ -10,6 +12,10 @@ logger = logging.getLogger("streamrip")
 class ArtistMetadata:
     name: str
     ids: list[str]
+    # One per id, in the same order. The artist response already carries the
+    # full album objects, so describing a discography costs no extra requests
+    # -- and AlbumSummary already knows how to read one from any source.
+    albums: list[AlbumSummary] = field(default_factory=list)
 
     def album_ids(self):
         return self.ids
@@ -18,10 +24,14 @@ class ArtistMetadata:
     def from_resp(cls, resp: dict, source: str) -> ArtistMetadata:
         logger.debug(resp)
         if source == "qobuz":
-            return cls(resp["name"], [a["id"] for a in resp["albums"]["items"]])
-        elif source == "tidal":
-            return cls(resp["name"], [a["id"] for a in resp["albums"]])
-        elif source == "deezer":
-            return cls(resp["name"], [a["id"] for a in resp["albums"]])
+            items = resp["albums"]["items"]
+        elif source in ("tidal", "deezer"):
+            items = resp["albums"]
         else:
             raise NotImplementedError
+
+        return cls(
+            resp["name"],
+            [str(a["id"]) for a in items],
+            [AlbumSummary.from_item(a) for a in items],
+        )

--- a/streamrip/metadata/search_results.py
+++ b/streamrip/metadata/search_results.py
@@ -115,6 +115,15 @@ class AlbumSummary(Summary):
     artist: str
     num_tracks: str
     date_released: str | None
+    # Best quality the source lists for this release, where it says. Tidal
+    # routinely lists the same album twice, once lossless and once hi-res,
+    # which is otherwise impossible to tell apart in a list.
+    quality: str = ""
+    # "album", "ep" or "single" where the source says so, otherwise empty.
+    # Tidal populates it; Qobuz leaves release_type null on every album, and
+    # guessing from the track count would put wrong labels on screen -- a
+    # four-track release is not reliably an EP.
+    release_type: str = ""
 
     def media_type(self):
         return "album"
@@ -123,14 +132,23 @@ class AlbumSummary(Summary):
         return f"{clean(self.name)} by {clean(self.artist)}"
 
     def preview(self) -> str:
-        return f"Date released:\n{self.date_released}\n\n{self.num_tracks} Tracks\n\nID: {self.id}"
+        quality = f"\n\n{self.quality}" if self.quality else ""
+        return (
+            f"Date released:\n{self.date_released}\n\n"
+            f"{self.num_tracks} Tracks{quality}\n\nID: {self.id}"
+        )
 
     @classmethod
     def from_item(cls, item: dict):
         id = str(item["id"])
         title = (item.get("title") or "").strip()
         version = (item.get("version") or "").strip()
-        name = title + (" (" + version + ")" if version else "")
+        # Sources often already have the edition in the title, which gave
+        # "Please Please Me (Remastered) (Remastered)".
+        if version and version.lower() not in title.lower():
+            name = f"{title} ({version})"
+        else:
+            name = title
         artist = (
             item.get("performer", {}).get("name")
             or item.get("artist", {}).get("name")
@@ -158,7 +176,22 @@ class AlbumSummary(Summary):
             or item.get("year")
             or "Unknown"
         )
-        return cls(id, name, artist, str(num_tracks), date_released)
+        tags = (item.get("mediaMetadata") or {}).get("tags") or []
+        if "HIRES_LOSSLESS" in tags:
+            quality = "hi-res"
+        elif tags:
+            quality = "lossless"
+        elif item.get("maximum_bit_depth") and item.get("maximum_sampling_rate"):
+            quality = f"{item['maximum_bit_depth']}bit/{item['maximum_sampling_rate']}kHz"
+        else:
+            quality = ""
+
+        declared = str(item.get("type") or item.get("release_type") or "").lower()
+        release_type = declared if declared in ("album", "ep", "single") else ""
+
+        return cls(
+            id, name, artist, str(num_tracks), date_released, quality, release_type
+        )
 
 
 @dataclass(slots=True)

--- a/streamrip/rip/cli.py
+++ b/streamrip/rip/cli.py
@@ -21,6 +21,7 @@ from .. import __version__, db
 from ..config import DEFAULT_CONFIG_PATH, Config, OutdatedConfigError, set_user_defaults
 from ..console import console
 from ..utils.ssl_utils import get_aiohttp_connector_kwargs
+from ..media.artist import Artist
 from .main import Main
 
 
@@ -199,16 +200,33 @@ def rip(
 
 @rip.command()
 @click.argument("urls", nargs=-1, required=True)
+@click.option(
+    "--no-confirm",
+    is_flag=True,
+    help="For artist urls, take every album instead of asking which ones.",
+)
+@click.option(
+    "--sort",
+    "sort_by",
+    type=click.Choice(["type", "date"]),
+    default=None,
+    help="Order the artist album list. Overrides cli.artist_album_sort.",
+)
 @click.pass_context
 @coro
-async def url(ctx, urls):
+async def url(ctx, urls, no_confirm, sort_by):
     """Download content from URLs."""
     if ctx.obj["config"] is None:
         return
 
+    if no_confirm:
+        Artist.confirm_selection = False
+
     try:
         with ctx.obj["config"] as cfg:
             cfg: Config
+            # The flag wins for this run; otherwise take the configured order.
+            Artist.sort_by = sort_by or cfg.session.cli.artist_album_sort
             updates = cfg.session.misc.check_for_updates
             if updates:
                 # Run in background

--- a/streamrip/rip/cli.py
+++ b/streamrip/rip/cli.py
@@ -3,6 +3,7 @@ import json
 import logging
 import os
 import shutil
+import signal
 import subprocess
 from functools import wraps
 from typing import Any
@@ -26,7 +27,39 @@ from .main import Main
 def coro(f):
     @wraps(f)
     def wrapper(*args, **kwargs):
-        return asyncio.run(f(*args, **kwargs))
+        async def run():
+            # Ctrl-C used to be ignored until whatever was in flight finished,
+            # so people force-killed it -- which skips the cleanup in
+            # Main.__aexit__ and strews __artwork directories through the
+            # library. Cancel the task instead, so the `async with Main(...)`
+            # blocks unwind normally and clean up after themselves.
+            task = asyncio.current_task()
+            loop = asyncio.get_running_loop()
+
+            def stop():
+                console.print(
+                    "\n[yellow]Stopping after the current downloads finish... "
+                    "(Ctrl-C again to force)"
+                )
+                if task is not None:
+                    task.cancel()
+
+            try:
+                loop.add_signal_handler(signal.SIGINT, stop)
+            except (NotImplementedError, RuntimeError):
+                # Windows, or no running loop to attach to; fall back to the
+                # default KeyboardInterrupt behaviour.
+                pass
+
+            return await f(*args, **kwargs)
+
+        try:
+            return asyncio.run(run())
+        except (asyncio.CancelledError, KeyboardInterrupt):
+            console.print("[green]Stopped. Partly-downloaded tracks were left")
+            console.print(
+                "[green]resumable -- re-run the same command to continue."
+            )
 
     return wrapper
 

--- a/streamrip/rip/main.py
+++ b/streamrip/rip/main.py
@@ -9,6 +9,7 @@ from .. import db
 from ..client import Client, DeezerClient, QobuzClient, SoundcloudClient, TidalClient
 from ..config import Config
 from ..console import console
+from ..utils import menu
 from ..media import (
     Media,
     Pending,
@@ -191,47 +192,21 @@ class Main:
                 return
             search_results = SearchResults.from_pages(source, media_type, pages)
 
-        if platform.system() == "Windows":  # simple term menu not supported for windows
-            from pick import pick
-
-            choices = pick(
-                search_results.results,
-                title=(
-                    f"{source.capitalize()} {media_type} search.\n"
-                    "Press SPACE to select, RETURN to download, CTRL-C to exit."
-                ),
-                multiselect=True,
-                min_selection_count=1,
-            )
-            assert isinstance(choices, list)
-
-            await self.add_all_by_id(
-                [(source, media_type, item.id) for item, _ in choices],
-            )
-
+        chosen_ind = menu.multi_select(
+            search_results.summaries(),
+            title=(
+                f"Results for {media_type} '{query}' from {source.capitalize()}\n"
+                "SPACE - select, ENTER - download, ESC - exit"
+            ),
+            previews=[r.preview() for r in search_results.results],
+        )
+        if not chosen_ind:
+            menu.announce_nothing_chosen()
         else:
-            from simple_term_menu import TerminalMenu
-
-            menu = TerminalMenu(
-                search_results.summaries(),
-                preview_command=search_results.preview,
-                preview_size=0.5,
-                title=(
-                    f"Results for {media_type} '{query}' from {source.capitalize()}\n"
-                    "SPACE - select, ENTER - download, ESC - exit"
-                ),
-                cycle_cursor=True,
-                clear_screen=True,
-                multi_select=True,
+            choices = search_results.get_choices(tuple(chosen_ind))
+            await self.add_all_by_id(
+                [(source, item.media_type(), item.id) for item in choices],
             )
-            chosen_ind = menu.show()
-            if chosen_ind is None:
-                console.print("[yellow]No items chosen. Exiting.")
-            else:
-                choices = search_results.get_choices(chosen_ind)
-                await self.add_all_by_id(
-                    [(source, item.media_type(), item.id) for item in choices],
-                )
 
     async def search_take_first(self, source: str, media_type: str, query: str):
         client = await self.get_logged_in_client(source)

--- a/streamrip/utils/menu.py
+++ b/streamrip/utils/menu.py
@@ -1,0 +1,63 @@
+"""The scrolling multi-select menu used for anything the user has to pick from.
+
+`rip search` grew this first; artist downloads need exactly the same thing, so
+it lives here rather than being written twice with the Windows fallback only
+handled in one of them.
+"""
+
+import platform
+
+from ..console import console
+
+
+def multi_select(
+    entries: list[str],
+    title: str,
+    previews: list[str] | None = None,
+) -> list[int]:
+    """Show `entries` and return the indices the user chose.
+
+    Empty if they chose nothing or backed out. `previews`, when given, must be
+    the same length as `entries`.
+    """
+    if not entries:
+        return []
+
+    if platform.system() == "Windows":
+        # simple-term-menu is unix only.
+        from pick import pick
+
+        chosen = pick(entries, title=title, multiselect=True, min_selection_count=0)
+        if not chosen:
+            return []
+        return [index for _, index in chosen]
+
+    from simple_term_menu import TerminalMenu
+
+    preview_command = None
+    if previews:
+        by_entry = dict(zip(entries, previews))
+
+        def preview_command(entry: str) -> str:  # noqa: F811
+            return by_entry.get(entry, "")
+
+    menu = TerminalMenu(
+        entries,
+        title=title,
+        preview_command=preview_command,
+        preview_size=0.4,
+        cycle_cursor=True,
+        clear_screen=True,
+        multi_select=True,
+        show_multi_select_hint=True,
+    )
+    chosen = menu.show()
+    if chosen is None:
+        return []
+    if isinstance(chosen, int):
+        return [chosen]
+    return list(chosen)
+
+
+def announce_nothing_chosen() -> None:
+    console.print("[yellow]No items chosen. Exiting.")


### PR DESCRIPTION
Two related fixes for the same complaint: an artist url downloads the whole discography, and there is no good way to stop it.

## Ctrl-C did not stop a download

Measured on a 16-track album: SIGINT was ignored, the process was still running ten seconds later, and it had to be killed outright.

```
mid-download:   .part=3  __artwork=1  flac=0
after SIGINT:   process STILL RUNNING after 10s  ->  had to SIGKILL
left behind:    __artwork directory, partial files
```

That matters beyond the annoyance, because force-killing skips `Main.__aexit__` and therefore `remove_artwork_tempdirs()`. Every interrupted run leaves an `__artwork` directory behind in the album folder. I found 448 of them in one library, and interrupted artist downloads are where they came from.

Cancelling the running task from a SIGINT handler lets the `async with Main(...)` blocks unwind normally, so cleanup runs:

```
after SIGINT:   process exited promptly
                __artwork=0        (cleanup ran)
re-run:         16 valid FLACs, no leftovers
```

and the user gets a message rather than a `KeyboardInterrupt` traceback.

## Artist downloads are all-or-nothing

Artist search is unreliable on both Qobuz and Tidal, so an artist url is easily the wrong person entirely — and even the right one brings a lot nobody asked for. There was no way to look before committing to it.

This shows the discography in the same scrolling multi-select menu `rip search` already uses, with the same SPACE/ENTER/ESC keys and the same preview pane:

```
The Beatles - 88 releases
SPACE - select, ENTER - download, ESC - exit

  4. 2025  Anthology Collection  [191 trk]  hi-res
  5. 2025  Anthology 4  [36 trk]  lossless
  6. 2025  Anthology 4  [36 trk]  hi-res
```

To do that the menu moves into `utils/menu.py` and both callers use it, so the Windows `pick` fallback is no longer implemented only for search.

**The listing costs no extra requests.** The artist response already carries the full album objects and `ArtistMetadata` was keeping only their ids. It now keeps the `AlbumSummary` that `search_results` already builds, which reads every source's field names (`tracks_count` / `nb_tracks` / `numberOfTracks`, and the various date fields) and folds `version` into the name.

### Sorting

Sources return a discography in their own order, which is not much use for eighty-odd releases. Sorted either by release type then date — albums, then EPs, then singles, each oldest first — or as one chronological list. Set with `cli.artist_album_sort`, overridden for a single run by `rip url --sort`. The config field is defaulted, so configs written before this still load.

Release type is only used **where the source reports it**. Tidal does; Qobuz leaves `release_type` null on every album, and guessing from the track count would put wrong labels on screen — a four-track release is not reliably an EP. Unknown entries are unlabelled and sort with the albums, so `type` degrades to plain chronological order rather than inventing groupings.

### Two fixes to AlbumSummary along the way

It gains an optional `quality`, defaulting to empty so existing construction is unaffected. Tidal lists the same release twice, once lossless and once hi-res, which is otherwise impossible to tell apart in a list. Search results show it in their preview pane for the same reason.

And it no longer doubles the edition in the name. The version was appended even when the title already contained it:

```
before:  Please Please Me (Remastered) (Remastered)
after:   Please Please Me (Remastered)
```

That affected `rip search` results too, not just this menu.

The artist menu builds its own entry lines rather than using `summarize()`, since every row there has the same artist and the useful columns are year, track count, kind and quality.

It only prompts when `stdin` is a terminal, so scripts and cron are unaffected, and `rip url --no-confirm` skips it for unattended runs.

## Testing

Interrupt behaviour verified end to end on a real 16-track album: interrupt, confirm the `__artwork` directory was cleaned up, re-run, finish with 16 files that all decode.

Album listing checked against a real 88-release artist — entries and preview pane built from live metadata, with no additional requests beyond the artist call that was already being made.

Both gates verified: no prompt when `stdin` is not a terminal, and none with `--no-confirm`.

`AlbumSummary` back-compatibility checked: five-argument construction still works and yields an empty `quality`; Qobuz items give `24bit/96kHz`, Tidal items give `hi-res` / `lossless`.

Both commits compile standalone. `pytest tests/` is unchanged at 59 passed / 1 failed, and that failure (`test_meta.py::test_album_metadata_qobuz`, a genre assertion) also fails on an unmodified `dev`.

I have not driven the menu itself programmatically — `simple_term_menu` needs a real tty — so the interactive behaviour is the part most worth a second pair of eyes.

## Note

While investigating the interrupt I also hit `KeyError: 'body'` from `latest_streamrip_version()` surfacing as "Task exception was never retrieved". #995 already fixes that, and more thoroughly than I had, so I have left it out of this branch.
