### PR TITLE
Keep single-track downloads in their disc subfolder

### DIFF
--- a/streamrip/media/track.py
+++ b/streamrip/media/track.py
@@ -227,17 +227,34 @@ class PendingSingle(Pending):
         quality = getattr(config, self.client.source).quality
         assert isinstance(quality, int)
         parent = config.downloads.folder
-        if config.filepaths.add_singles_to_folder:
-            folder = self._format_folder(album)
+        in_album_folder = config.filepaths.add_singles_to_folder
+        if in_album_folder:
+            album_folder = self._format_folder(album)
         else:
-            folder = parent
+            album_folder = parent
 
-        os.makedirs(folder, exist_ok=True)
+        os.makedirs(album_folder, exist_ok=True)
 
         embedded_cover_path, downloadable = await asyncio.gather(
-            self._download_cover(album.covers, folder),
+            self._download_cover(album.covers, album_folder),
             self.client.get_downloadable(self.id, quality),
         )
+
+        # Mirror PendingTrack: a track belonging to a multi-disc album lives in
+        # that album's disc subfolder. Without this, downloading one track of a
+        # multi-disc album (`rip repair`, or any single-track URL) drops it
+        # beside the Disc folders rather than into the one it belongs to.
+        # Only meaningful when we're actually building the album's folder --
+        # otherwise this would create a bare "Disc N" in the download root.
+        folder = album_folder
+        if (
+            in_album_folder
+            and config.downloads.disc_subdirectories
+            and album.disctotal > 1
+        ):
+            folder = os.path.join(album_folder, f"Disc {meta.discnumber}")
+            os.makedirs(folder, exist_ok=True)
+
         return Track(
             meta,
             downloadable,

--- a/streamrip/metadata/album.py
+++ b/streamrip/metadata/album.py
@@ -103,7 +103,13 @@ class AlbumMetadata:
         label = typed(_label or "", str)
         description = typed(resp.get("description", ""), str)
         disctotal = typed(
-            max(
+            # "media_count" is authoritative and is present even when the album
+            # object is abbreviated. The track list is only embedded in a full
+            # album response, so deriving the disc count from it alone collapses
+            # to 1 for any album reached via a track (e.g. a single-track URL or
+            # `rip repair`), which then loses the "Disc N" subfolder.
+            resp.get("media_count")
+            or max(
                 track.get("media_number", 1)
                 for track in safe_get(resp, "tracks", "items", default=[{}])  # type: ignore
             )


### PR DESCRIPTION
Downloading a single track from a multi-disc album puts it in the album root rather than its `Disc N` subfolder, so it ends up sitting beside the disc folders instead of rejoining the album it belongs to.

This affects any single-track url, and every track fetched by a repair-style retry, since those resolve as singles.

## Two causes

**`PendingSingle.resolve()` never applied the disc-subfolder logic** that `PendingTrack.resolve()` already had.

**More importantly, `disctotal` was always 1 for anything reached through a track.** `AlbumMetadata.from_qobuz` derives it from `resp["tracks"]["items"]`:

```python
disctotal = typed(
    max(track.get("media_number", 1)
        for track in safe_get(resp, "tracks", "items", default=[{}]))
    or 1,
    int,
)
```

The album object embedded in a *track* response is abbreviated and carries no track list, so that falls back to `[{}]` and yields 1 — and a `disctotal` of 1 disables disc subfolders entirely. Fixing only the first cause changes nothing, which is what makes this one easy to miss.

Qobuz returns `media_count` on the album object, and it is present even on the abbreviated one, so prefer it and keep the existing computation as a fallback.

## Effect

Track `387281382`, disc 2 of a 3-disc album, with `add_singles_to_folder` on:

```
before:  .../Album Title [39 tracks]
after:   .../Album Title [39 tracks]/Disc 2
```

A single-disc album still resolves to the album folder, unchanged.

This also corrects the `DISCTOTAL` tag written for single-track downloads, which had the same wrong value for the same reason.

## Notes

The disc-subfolder branch in `PendingSingle` is gated on `add_singles_to_folder`, so it cannot create a bare `Disc N` directory in the download root when singles are not being foldered.

Full album responses are unaffected — `media_count` and the old computation agree there. Checked against three albums (3-disc, 1-disc, 1-disc): `disctotal` 3, 1, 1 both before and after.
