### PR TITLE
Keep the album edition in the title, tags and folder name

### DIFF
--- a/streamrip/metadata/album.py
+++ b/streamrip/metadata/album.py
@@ -50,6 +50,8 @@ class AlbumMetadata:
     grouping: str | None = None
     lyrics: str | None = None
     purchase_date: str | None = None
+    # Edition name, e.g. "Deluxe Edition". Only some sources provide one.
+    version: str | None = None
 
     def get_genres(self) -> str:
         return ", ".join(self.genre)
@@ -64,7 +66,11 @@ class AlbumMetadata:
 
     def format_folder_path(self, formatter: str) -> str:
         # Available keys: "albumartist", "title", "year", "bit_depth", "sampling_rate",
-        # "id", and "albumcomposer",
+        # "id", "albumcomposer", "container", "tracktotal", and "version".
+        #
+        # Two different editions of the same album can otherwise render to the
+        # same folder and get merged together -- "tracktotal" and "version"
+        # give a readable way to tell them apart without resorting to "id".
 
         none_str = "Unknown"
         info: dict[str, str | int | float] = {
@@ -76,6 +82,8 @@ class AlbumMetadata:
             "title": clean_filename(self.album),
             "year": self.year,
             "container": self.info.container,
+            "tracktotal": self.tracktotal,
+            "version": clean_filename(self.version or "") or none_str,
         }
 
         return clean_filepath(formatter.format(**info))
@@ -83,6 +91,13 @@ class AlbumMetadata:
     @classmethod
     def from_qobuz(cls, resp: dict) -> AlbumMetadata:
         album = resp.get("title", "Unknown Album")
+        version = resp.get("version")
+        # The edition is part of what the album *is* -- a standard and a deluxe
+        # release otherwise share a title, so they tag identically and collide
+        # in the same download folder. Fold it into the title (unless the title
+        # already says it) and keep it in `version` for tagging as well.
+        if version and version.lower() not in album.lower():
+            album = f"{album} ({version})"
         tracktotal = resp.get("tracks_count", 1)
         genre = [safe_get(resp, "genre", "name")] or resp.get("genre") or []
         genres = list(set(genre_clean.findall("/".join(genre))))
@@ -156,6 +171,7 @@ class AlbumMetadata:
             lyrics=None,
             purchase_date=None,
             tracktotal=tracktotal,
+            version=resp.get("version"),
         )
 
     @classmethod

--- a/streamrip/metadata/tagger.py
+++ b/streamrip/metadata/tagger.py
@@ -88,6 +88,11 @@ METADATA_TYPES = (
     "disctotal",
     "date",
     "isrc",
+    # Keep "version" last: MP3_KEY/MP4_KEY zip this tuple against their own
+    # positional key tuples, so a trailing entry with no counterpart is simply
+    # dropped for those formats. FLAC_KEY is built by comprehension and picks
+    # it up as the standard Vorbis VERSION field.
+    "version",
 )
 
 


### PR DESCRIPTION
Two different editions of the same album can download into the same folder and merge together.

A standard and a deluxe release share a title, a year and often a format, so every key available to `folder_format` renders identically for both, and the second download lands on top of the first. I ended up with one folder holding a 25-track edition loose in the root and a 39-track 3-disc edition in subfolders, which took a while to work out.

## Keep the edition

Qobuz returns it in a `version` field, which is currently discarded. This folds it into the album title unless the title already says it, so `Into the Gap` becomes `Into the Gap (Deluxe Edition)` — in the `ALBUM` tag and therefore in the folder name — and keeps it on `AlbumMetadata` as well.

FLAC also gets a standard Vorbis `VERSION` field. `"version"` is deliberately last in `METADATA_TYPES`: `MP3_KEY` and `MP4_KEY` are built by zipping that tuple against their own positional key tuples, so a trailing entry with no counterpart is dropped for those formats, while `FLAC_KEY` is a dict comprehension and picks it up. Verified the MP3/MP4 mappings are unshifted (`title→TIT2/©nam`, `album→TALB/©alb`, `isrc→TSRC/…`).

## `{tracktotal}` and `{version}` for folder_format

Version alone is not always enough. The two editions that collided for me are *both* called "Deluxe Edition":

| | id | title | version | format |
|---|---|---|---|---|
| 25-track | `vegp0b121e5it` | Into the Gap | Deluxe Edition | 1984 · FLAC 16/44.1 |
| 39-track | `grid9ukxx5fx1` | Into the Gap | Deluxe Edition | 1984 · FLAC 16/44.1 |

Every existing key is identical across those two. `{tracktotal}` tells them apart and stays readable, which `{id}` — the only currently-unique option — does not:

```
Thompson Twins - Into the Gap (Deluxe Edition) (1984) [FLAC] [16B-44.1kHz] [25 tracks]
Thompson Twins - Into the Gap (Deluxe Edition) (1984) [FLAC] [16B-44.1kHz] [39 tracks]
```

Both are now exposed to `folder_format`, alongside the existing keys.

## Compatibility note

Folding the version into the title changes folder names for releases that have one, so an existing library will not match what this generates. Nothing breaks day to day, since the downloads database prevents re-downloading, but re-fetching an album can create a second folder under the new naming. Worth deciding deliberately — I think the collision is the worse problem, but it is a behaviour change rather than a pure fix, and I am happy to put the title change behind an option if you would prefer.

`{tracktotal}` and `{version}` on their own are purely additive: nothing changes unless they are added to `folder_format`.

## Testing

Both editions resolved from live metadata:

```
vegp0b121e5it  album='Into the Gap (Deluxe Edition)'  version='Deluxe Edition'
grid9ukxx5fx1  album='Into the Gap (Deluxe Edition)'  version='Deluxe Edition'

with {tracktotal}:
  ... [16B-44.1kHz] [25 tracks]
  ... [16B-44.1kHz] [39 tracks]
```

`pytest tests/` unchanged: 59 passed, 1 failed, and that failure (`test_meta.py::test_album_metadata_qobuz`, a genre assertion) also fails on an unmodified `dev`.
