### PR TITLE
Offer a fresh login when saved credentials stop working

### DIFF
--- a/streamrip/client/tidal.py
+++ b/streamrip/client/tidal.py
@@ -9,7 +9,11 @@ from json import JSONDecodeError
 import aiohttp
 
 from ..config import Config
-from ..exceptions import NonStreamableError
+from ..exceptions import (
+    AuthenticationError,
+    MissingCredentialsError,
+    NonStreamableError,
+)
 from .client import Client
 from .downloadable import TidalDownloadable
 
@@ -55,7 +59,9 @@ class TidalClient(Client):
         )
         c = self.config
         if not c.access_token:
-            raise Exception("Access token not found in config.")
+            raise MissingCredentialsError(
+                "No Tidal access token in config -- Tidal has not been set up yet."
+            )
 
         self.token_expiry = float(c.token_expiry)
         self.refresh_token = c.refresh_token
@@ -300,7 +306,13 @@ class TidalClient(Client):
         resp = await self._api_post(f"{AUTH_URL}/token", data, AUTH)
 
         if resp.get("status", 200) != 200:
-            raise Exception("Refresh failed")
+            # The refresh token itself has lapsed or been revoked, so there is
+            # nothing left to refresh from and only a fresh device login will
+            # help. Typed so the caller can offer that instead of dying with a
+            # traceback.
+            raise AuthenticationError(
+                "Tidal refresh token has expired or been revoked."
+            )
 
         c = self.config
         c.access_token = resp["access_token"]

--- a/streamrip/rip/main.py
+++ b/streamrip/rip/main.py
@@ -2,13 +2,16 @@ import asyncio
 import json
 import logging
 import platform
+import sys
 
 import aiofiles
+from rich.prompt import Confirm
 
 from .. import db
 from ..client import Client, DeezerClient, QobuzClient, SoundcloudClient, TidalClient
 from ..config import Config
 from ..console import console
+from ..exceptions import AuthenticationError, MissingCredentialsError
 from ..media import (
     Media,
     Pending,
@@ -145,12 +148,41 @@ class Main:
                 await prompter.prompt_and_login()
                 prompter.save()
             else:
-                with console.status(f"[cyan]Logging into {source}", spinner="dots"):
-                    # Log into client using credentials from config
-                    await client.login()
+                try:
+                    with console.status(
+                        f"[cyan]Logging into {source}", spinner="dots"
+                    ):
+                        # Log into client using credentials from config
+                        await client.login()
+                except (AuthenticationError, MissingCredentialsError) as e:
+                    # has_creds() only checks that something is *stored*, not
+                    # that it still works. Saved tokens expire, so the usual
+                    # way to discover a lapsed login is a failure here -- which
+                    # used to be a bare traceback, even though the prompter
+                    # that fixes it is already built and sitting right there.
+                    await self._reauthenticate(source, prompter, e)
 
         assert client.logged_in
         return client
+
+    async def _reauthenticate(self, source: str, prompter, cause: Exception):
+        """Offer a fresh login after stored credentials stop working."""
+        console.print(f"[yellow]{source.title()} login failed: {cause}")
+
+        # Never block on a prompt nobody is there to answer: rip is run from
+        # cron and from scripts, where a hidden y/n means hanging forever
+        # rather than failing.
+        if not sys.stdin.isatty():
+            raise AuthenticationError(
+                f"{source} needs authorising again. Re-run this from an "
+                f"interactive terminal and you will be prompted to log in."
+            ) from cause
+
+        if not Confirm.ask(f"Log into {source} again now?"):
+            raise cause
+
+        await prompter.prompt_and_login()
+        prompter.save()
 
     async def resolve(self):
         """Resolve all currently pending items."""

--- a/tests/test_reauth_prompt.py
+++ b/tests/test_reauth_prompt.py
@@ -1,0 +1,74 @@
+"""Stored credentials that stop working should offer a fresh login.
+
+`has_creds()` only checks that something is *stored*, not that it still works,
+so an expired token passes that check and the failure surfaces from `login()`.
+Before this was handled, that meant a traceback -- even though the prompter
+that fixes it was already built.
+"""
+
+from contextlib import ExitStack
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from streamrip.exceptions import AuthenticationError
+from streamrip.rip.main import Main
+
+
+def _main_with_expired_token():
+    main = Main.__new__(Main)
+    client = MagicMock()
+    client.logged_in = False
+    client.login = AsyncMock(
+        side_effect=AuthenticationError("Tidal refresh token has expired.")
+    )
+    main.clients = {"tidal": client}
+    main.config = MagicMock()
+
+    prompter = MagicMock()
+    prompter.has_creds.return_value = True
+    prompter.prompt_and_login = AsyncMock(
+        side_effect=lambda: setattr(client, "logged_in", True)
+    )
+    return main, client, prompter
+
+
+def _patches(prompter, *, isatty: bool, confirm: bool):
+    stack = ExitStack()
+    stack.enter_context(
+        patch("streamrip.rip.main.get_prompter", return_value=prompter)
+    )
+    stack.enter_context(patch("sys.stdin.isatty", return_value=isatty))
+    stack.enter_context(
+        patch("streamrip.rip.main.Confirm.ask", return_value=confirm)
+    )
+    return stack
+
+
+@pytest.mark.asyncio
+async def test_prompts_and_recovers_when_user_agrees():
+    main, client, prompter = _main_with_expired_token()
+    with _patches(prompter, isatty=True, confirm=True):
+        result = await main.get_logged_in_client("tidal")
+    prompter.prompt_and_login.assert_awaited_once()
+    prompter.save.assert_called_once()
+    assert result is client
+
+
+@pytest.mark.asyncio
+async def test_propagates_when_user_declines():
+    main, _, prompter = _main_with_expired_token()
+    with _patches(prompter, isatty=True, confirm=False):
+        with pytest.raises(AuthenticationError, match="refresh token has expired"):
+            await main.get_logged_in_client("tidal")
+    prompter.prompt_and_login.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_never_prompts_without_a_terminal():
+    """rip runs from cron and from scripts, where a hidden y/n hangs forever."""
+    main, _, prompter = _main_with_expired_token()
+    with _patches(prompter, isatty=False, confirm=True):
+        with pytest.raises(AuthenticationError, match="interactive terminal"):
+            await main.get_logged_in_client("tidal")
+    prompter.prompt_and_login.assert_not_awaited()


### PR DESCRIPTION
## Problem

`has_creds()` only checks that a credential is *stored*, not that it still works:

```python
def has_creds(self) -> bool:
    return len(self.config.session.tidal.access_token) > 0
```

An expired token is still a non-empty string. So the check passes, `login()` is
attempted, and the failure surfaces as a bare traceback — even though the
prompter that would fix it is already built, and is reached in the
`has_creds() == False` branch a few lines above.

For Tidal the two failure points were untyped, so nothing could catch them
precisely:

```python
raise Exception("Access token not found in config.")   # never set up
raise Exception("Refresh failed")                      # refresh token lapsed
```

The second is the common one. Tidal access tokens are refreshed automatically,
but the *refresh* token eventually expires too, and when it does there is
nothing left to refresh from. Today that ends in:

```
TypeError: 'NoneType' object does not support the context manager protocol
```

## Change

`get_logged_in_client()` catches `AuthenticationError` and
`MissingCredentialsError` from `login()` and offers a fresh login.

Qobuz and Deezer already raise those types, so the only change needed to cover
all three sources was giving Tidal's two bare `Exception`s the same types.

Declining re-raises the original error, so nothing is swallowed.

**Non-interactive runs never prompt.** `rip` is used from cron and from
scripts, where a hidden y/n hangs forever instead of failing. Without a tty it
raises with an explanation instead, following the `sys.stdin.isatty()` guard
already used for artist album selection.

## Relationship to #955

**#955 by @mikelandzelo173 got here first** and modifies the same lines,
wrapping `await client.login()` in `try/except AuthenticationError`. Its
handler is deliberately Qobuz-only:

```python
except AuthenticationError:
    if source != "qobuz":
        raise
```

That PR's real subject is the new Qobuz token flow; this one takes the same
idea and generalises it — every source, both credential exception types, and a
guard for non-interactive use.

**These will conflict.** They should not both be merged as-is. If #955 lands
first I am happy to rebase this on top and reduce it to the generalisation, or
to close it if the Qobuz-specific form is preferred. Flagging it rather than
letting a merge conflict be the discovery.

## Testing

`tests/test_reauth_prompt.py` covers three paths — accept, decline, and no
tty — and each fails without this change.

```
3 passed
```

Full suite: 62 passed, 7 skipped. `tests/test_meta.py::test_album_metadata_qobuz`
fails, but it fails identically on unmodified `dev`.
