### PR TITLE
fix(qobuz): auto-refetch app id/secrets on stale credential error

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ pathvalidate = "^2.4.1"
 simple-term-menu = { version = "^1.2.1", platform = 'darwin|linux' }
 pick = { version = "^2", platform = 'win32|cygwin' }
 windows-curses = { version = "^2.2.0", platform = 'win32|cygwin' }
-Pillow = ">=9,<11"
+Pillow = ">=9"
 deezer-py = "1.3.6"
 pycryptodomex = "^3.10.1"
 appdirs = "^1.4.4"

--- a/streamrip/client/qobuz.py
+++ b/streamrip/client/qobuz.py
@@ -171,13 +171,33 @@ class QobuzClient(Client):
 
         if not c.app_id or not c.secrets:
             logger.info("App id/secrets not found, fetching")
-            c.app_id, c.secrets = await self._get_app_id_and_secrets()
-            # write to file
-            f = self.config.file
-            f.qobuz.app_id = c.app_id
-            f.qobuz.secrets = c.secrets
-            f.set_modified()
+            await self._refresh_app_id_and_secrets()
 
+        # A stale app_id/secret pair (e.g. hardcoded in the config after Qobuz
+        # rotated its app secret) fails with InvalidAppIdError or
+        # InvalidAppSecretError. Re-fetch a fresh pair from the bundle and retry
+        # once before giving up.
+        try:
+            await self._attempt_login()
+        except (InvalidAppIdError, InvalidAppSecretError) as e:
+            logger.warning("Login failed with %s, refetching app id/secrets", e)
+            self.session.headers.pop("X-User-Auth-Token", None)
+            await self._refresh_app_id_and_secrets()
+            await self._attempt_login()
+
+        self.logged_in = True
+
+    async def _refresh_app_id_and_secrets(self):
+        c = self.config.session.qobuz
+        c.app_id, c.secrets = await self._get_app_id_and_secrets()
+        # write to file
+        f = self.config.file
+        f.qobuz.app_id = c.app_id
+        f.qobuz.secrets = c.secrets
+        f.set_modified()
+
+    async def _attempt_login(self):
+        c = self.config.session.qobuz
         self.session.headers.update({"X-App-Id": str(c.app_id)})
 
         if c.use_auth_token:
@@ -211,8 +231,6 @@ class QobuzClient(Client):
         self.session.headers.update({"X-User-Auth-Token": uat})
 
         self.secret = await self._get_valid_secret(c.secrets)
-
-        self.logged_in = True
 
     async def get_metadata(self, item: str, media_type: str):
         if media_type == "label":


### PR DESCRIPTION
Qobuz periodically rotates its app secret. A stale app_id/secret pair (hardcoded in the config, or cached from a previous run) still passes the lenient user/login check but fails secret validation against track/getFileUrl with a 400, surfacing as InvalidAppSecretError (or InvalidAppIdError) and a hard login failure.

login() now splits into _attempt_login() and _refresh_app_id_and_secrets(). On InvalidAppIdError/InvalidAppSecretError it refetches a fresh pair from the web bundle, persists it to the config file, and retries once, so a secret rotation self-heals on the next run even when app_id/secrets are pinned in the config.

Also relax the Pillow constraint to ">=9".