### PR TITLE
fix: bump http.client._MAXHEADERS to 1000 to prevent CDN header drops

### DIFF
--- a/streamrip/__init__.py
+++ b/streamrip/__init__.py
@@ -1,3 +1,8 @@
+import http.client
+
+# Prevent failures on CDNs (like Qobuz/Akamai) that send >100 response headers
+http.client._MAXHEADERS = 1000
+
 from . import converter, db, exceptions, media, metadata
 from .config import Config
 


### PR DESCRIPTION
### Problem
Certain CDNs (notably Akamai/Qobuz edge nodes on high-profile releases like `https://open.qobuz.com/track/212116885`) return over 100 response headers, primarily bloated cookie and telemetry headers. 

Because Python's standard `http.client` hardcodes an internal limit of 100 headers (`_MAXHEADERS = 100`), requests abort immediately with:
```text
ERROR    Error downloading track: ('Connection aborted.', HTTPException('got more than 100 headers'))
ERROR    Error processing media item: file said 4 bytes, read 0 bytes
```
### Solution

Increases http.client._MAXHEADERS to 1000 in streamrip/__init__.py during startup, allowing requests to complete successfully across all affected CDN endpoints without breaking downloads.