### PR TITLE
Don't let a failed lyrics fetch abort the track

### DIFF
--- a/streamrip/client/tidal.py
+++ b/streamrip/client/tidal.py
@@ -353,7 +353,7 @@ class TidalClient(Client):
         async with self.rate_limiter:
             async with self.session.get(f"{base}/{path}", params=params) as resp:
                 if resp.status == 404:
-                    logger.warning("TIDAL: track not found", resp)
+                    logger.warning("TIDAL: item not found (404): %s", resp.url)
                     raise NonStreamableError("TIDAL: Track not found")
                 resp.raise_for_status()
                 return await resp.json()

--- a/streamrip/client/tidal.py
+++ b/streamrip/client/tidal.py
@@ -9,7 +9,7 @@ from json import JSONDecodeError
 import aiohttp
 
 from ..config import Config
-from ..exceptions import NonStreamableError
+from ..exceptions import ItemNotFoundError, NonStreamableError
 from .client import Client
 from .downloadable import TidalDownloadable
 
@@ -124,12 +124,13 @@ class TidalClient(Client):
                     item["lyrics"] = resp.get("lyrics") or ""
                 else:
                     item["lyrics"] = resp.get("subtitles") or resp.get("lyrics") or ""
+            except ItemNotFoundError:
+                # Most tracks simply have no lyrics. That is the expected
+                # answer, not a problem worth reporting.
+                logger.debug("No lyrics available for track %s", item_id)
             except (NonStreamableError, TypeError) as e:
-                # Lyrics are optional. The endpoint 404s for any track that
-                # has none, which _api_request turns into NonStreamableError
-                # -- previously that escaped get_metadata() and the caller
-                # dropped the track as unstreamable, so a track was skipped
-                # for the sole reason that nobody had written lyrics for it.
+                # Lyrics that should have been there but could not be
+                # fetched -- worth knowing about.
                 logger.warning(f"Failed to get lyrics for {item_id}: {e}")
 
         logger.debug(item)
@@ -358,7 +359,10 @@ class TidalClient(Client):
         async with self.rate_limiter:
             async with self.session.get(f"{base}/{path}", params=params) as resp:
                 if resp.status == 404:
-                    logger.warning("TIDAL: item not found (404): %s", resp.url)
-                    raise NonStreamableError("TIDAL: Track not found")
+                    # Logged at debug, not warning: some callers ask for
+                    # optional things (lyrics) where a 404 is the normal
+                    # answer. Callers that do care log it themselves.
+                    logger.debug("TIDAL: item not found (404): %s", resp.url)
+                    raise ItemNotFoundError(f"TIDAL: item not found: {resp.url}")
                 resp.raise_for_status()
                 return await resp.json()

--- a/streamrip/client/tidal.py
+++ b/streamrip/client/tidal.py
@@ -124,7 +124,12 @@ class TidalClient(Client):
                     item["lyrics"] = resp.get("lyrics") or ""
                 else:
                     item["lyrics"] = resp.get("subtitles") or resp.get("lyrics") or ""
-            except TypeError as e:
+            except (NonStreamableError, TypeError) as e:
+                # Lyrics are optional. The endpoint 404s for any track that
+                # has none, which _api_request turns into NonStreamableError
+                # -- previously that escaped get_metadata() and the caller
+                # dropped the track as unstreamable, so a track was skipped
+                # for the sole reason that nobody had written lyrics for it.
                 logger.warning(f"Failed to get lyrics for {item_id}: {e}")
 
         logger.debug(item)

--- a/streamrip/exceptions.py
+++ b/streamrip/exceptions.py
@@ -66,5 +66,14 @@ class NonStreamableError(Exception):
         return " ".join(base_msg)
 
 
+class ItemNotFoundError(NonStreamableError):
+    """The API returned 404 for an item.
+
+    A subclass of NonStreamableError so existing handlers are unaffected, but
+    distinguishable for callers fetching something optional -- "this does not
+    exist" and "this failed to download" deserve different log levels.
+    """
+
+
 class ConversionError(Exception):
     """ConversionError."""

--- a/streamrip/rip/parse_url.py
+++ b/streamrip/rip/parse_url.py
@@ -20,6 +20,7 @@ logger = logging.getLogger("streamrip")
 URL_REGEX = re.compile(
     r"https?://(?:www|open|play|listen)?\.?(qobuz|tidal|deezer)\.com?(?:(?:/(album|artist|track|playlist|video|label))|(?:\/[-\w]+?))+\/([-\w]+)",
 )
+TIDAL_SHARE_SUFFIX_REGEX = re.compile(r"^(https?://[^/]*tidal\.com/.+?)/u/?$")
 SOUNDCLOUD_URL_REGEX = re.compile(r"https://soundcloud.com/[-\w:/]+")
 LASTFM_URL_REGEX = re.compile(r"https://www.last.fm/user/\w+/playlists/\w+")
 QOBUZ_INTERPRETER_URL_REGEX = re.compile(
@@ -54,6 +55,12 @@ class URL(ABC):
 class GenericURL(URL):
     @classmethod
     def from_str(cls, url: str) -> URL | None:
+        # Tidal's share sheet produces links ending in "/u". URL_REGEX takes
+        # the last path segment as the item id -- it has to, because Qobuz
+        # album urls look like /<locale>/album/<slug>/<id> -- so that suffix
+        # would be parsed as an id of "u" and the API would 404.
+        url = TIDAL_SHARE_SUFFIX_REGEX.sub(r"\1", url)
+
         generic_url = URL_REGEX.match(url)
         if generic_url is None:
             return None

--- a/tests/test_parse_url.py
+++ b/tests/test_parse_url.py
@@ -51,6 +51,28 @@ class TestParseURL(unittest.TestCase):
         self.assertEqual(groups[1], "track")  # media_type
         self.assertEqual(groups[2], "3083287")  # item_id
 
+    def test_tidal_share_url_with_u_suffix(self):
+        """Test that Tidal share links ending in /u parse to the real item id.
+
+        The share sheet appends "/u", which would otherwise be taken as the
+        item id and 404 against the API.
+        """
+        for url in (
+            "https://tidal.com/album/152697662/u",
+            "https://tidal.com/album/152697662/u/",
+            "https://tidal.com/browse/album/152697662/u",
+        ):
+            with self.subTest(url=url):
+                result = parse_url(url)
+
+                self.assertIsNotNone(result)
+                self.assertIsInstance(result, GenericURL)
+                self.assertEqual(result.source, "tidal")
+
+                groups = result.match.groups()
+                self.assertEqual(groups[1], "album")  # media_type
+                self.assertEqual(groups[2], "152697662")  # item_id
+
     def test_deezer_track_url(self):
         """Test that Deezer track URLs are matched correctly."""
         url = "https://www.deezer.com/track/4195713"


### PR DESCRIPTION
## Problem

Issue #959: on Tidal, a non-2xx response from the lyrics endpoint aborts the track it belongs to. Every track in the album fails with `Error downloading track: 401, message='Unauthorized', url='…/lyrics…'`, the audio request is never made, and only `cover.jpg` is written.

Lyrics are optional, so this should never cost the track. #1024 contains a 404 — the normal answer for a track without lyrics — but any other failure still escapes as `aiohttp.ClientResponseError` (or `asyncio.TimeoutError`) out of `get_metadata()`.

## Change

The lyrics `except` also catches `aiohttp.ClientError` and `asyncio.TimeoutError`, logs a warning, and carries on without lyrics. A failure of the *track* request itself is unaffected and still raises.

One side effect worth stating: a rate-limited (429) lyrics call now costs the lyrics rather than the track.

## Builds on #1024

This is stacked on #1024 because both change the same `except` block; a separate branch from `dev` would conflict with it. **Only the last commit is new** — the first four are #1024's. If #1024 merges first, this reduces to a single commit.

## Testing

`tests/test_tidal_lyrics_failure.py`:

- a 401 from the lyrics endpoint is contained and logged
- a timeout is contained
- a 404 stays quiet, as in #1024
- a failure of the track request itself still raises

The first two fail without this change. Full suite: 64 passed, 7 skipped; `tests/test_meta.py::test_album_metadata_qobuz` fails identically on unmodified `dev`.

I can't reproduce the 401 live right now — the lyrics endpoint currently returns 200 for my account — but it was still being reported against `dev` on 28 August.

Fixes #959
